### PR TITLE
OCM-10641 | fix: only takes the variable when not empty

### DIFF
--- a/modules/account-iam-resources/main.tf
+++ b/modules/account-iam-resources/main.tf
@@ -25,7 +25,7 @@ locals {
     },
   ]
   account_roles_count = length(local.account_roles_properties)
-  account_role_prefix_valid = var.account_role_prefix != null ? (
+  account_role_prefix_valid = (var.account_role_prefix != null && var.account_role_prefix != "") ? (
     var.account_role_prefix
     ) : (
     "account-role-${random_string.default_random[0].result}"


### PR DESCRIPTION
[OCM-10641](https://issues.redhat.com//browse/OCM-10641)