### PR TITLE
OCM-10641 | fix: ensure operator role prefix var for submodule is mandatory

### DIFF
--- a/modules/operator-roles/README.md
+++ b/modules/operator-roles/README.md
@@ -64,7 +64,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_oidc_endpoint_url"></a> [oidc\_endpoint\_url](#input\_oidc\_endpoint\_url) | oidc provider url | `string` | n/a | yes |
-| <a name="input_operator_role_prefix"></a> [operator\_role\_prefix](#input\_operator\_role\_prefix) | Prefix to be used when creating the operator roles | `string` | `"tf-op"` | no |
+| <a name="input_operator_role_prefix"></a> [operator\_role\_prefix](#input\_operator\_role\_prefix) | Prefix to be used when creating the operator roles | `string` | n/a | yes |
 | <a name="input_path"></a> [path](#input\_path) | (Optional) The arn path for the account/operator roles as well as their policies. Must begin and end with '/'. | `string` | `"/"` | no |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | The ARN of the policy that is used to set the permissions boundary for the IAM roles in STS clusters. | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | List of AWS resource tags to apply. | `map(string)` | `null` | no |

--- a/modules/operator-roles/variables.tf
+++ b/modules/operator-roles/variables.tf
@@ -1,7 +1,6 @@
 variable "operator_role_prefix" {
   type = string
   description = "Prefix to be used when creating the operator roles"
-  default = "tf-op"
 }
 
 variable "path" {


### PR DESCRIPTION
[OCM-10641](https://issues.redhat.com//browse/OCM-10641)