### PR TITLE
OCM-10641 | fix: check account role prefix is not empty to setup random part

### DIFF
--- a/modules/account-iam-resources/main.tf
+++ b/modules/account-iam-resources/main.tf
@@ -68,7 +68,7 @@ resource "aws_iam_role_policy_attachment" "account_role_policy_attachment" {
 }
 
 resource "random_string" "default_random" {
-  count = var.account_role_prefix != null ? 0 : 1
+  count = (var.account_role_prefix != null && var.account_role_prefix != "") ? 0 : 1
 
   length  = 4
   special = false


### PR DESCRIPTION
[OCM-10641](https://issues.redhat.com//browse/OCM-10641)