### PR TITLE
Ignore `rhcs_cluster_rosa_hcp` properties changes

### DIFF
--- a/modules/rosa-cluster-hcp/main.tf
+++ b/modules/rosa-cluster-hcp/main.tf
@@ -116,6 +116,14 @@ resource "rhcs_cluster_rosa_hcp" "rosa_hcp_cluster" {
       ) == false
       error_message = "Autoscaler parameters cannot be modified while the cluster autoscaler is disabled. Please ensure that cluster_autoscaler_enabled variable is set to true"
     }
+
+    # Mitigation: allow different user identities to create and update the terraform project
+    #   When using AWS STS ephemeral tokens, it creates different identities every hour.
+    #   Without ignoring the properties, that contains the `rosa_creator_arn` key, it will fail
+    #   the `apply` after the token being refreshed.
+    #
+    #   Probably the right fix is to ignore this field change in the provider or remove this value entirely.
+    ignore_changes = [ properties ]
   }
 }
 


### PR DESCRIPTION
## Why

Currently, only the same AWS user who created the ROSA cluster is able to update it.

This is a bigger problem if we decide to use AWS STS ephemeral identities. We can't upgrade the cluster, because our identity will have a different identifier code every single time.

## How to reproduce the bug

1. Create an AWS `userA`
2. Use `userA` to create the cluster using `terraform apply`
3. Create an AWS `userB`
4. Use `userB` to update the cluster using `terraform apply`

## Mitigation

My PR goal is to ignore changes in everything inside the `properties`.

Probably the right fix is to ignore this field change in the provider or remove this value entirely.