### PR TITLE
chore: Add 'hunterkepley' to OWNERS file + add `idea/*` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 **/.terraform/*
 **/.terraform.lock.hcl
 
+.idea/*
+
 # .tfstate files
 *.tfstate
 *.tfstate.*

--- a/OWNERS
+++ b/OWNERS
@@ -6,3 +6,4 @@ approvers:
 - gdbranco
 - ciaranRoche
 - robpblake
+- hunterkepley


### PR DESCRIPTION
I use an IntelliJ IDEA editor for my work, this prevents it's configuration files from being pushed to the repo (GoLand IDE)

I am the new lead for TF and ROSA CLI, so I need access to push tags for release + approve MRs