### PR TITLE
fix: update aws_account_arn assignment to use issuer_arn from aws_iam…

### DIFF
--- a/modules/rosa-cluster-hcp/main.tf
+++ b/modules/rosa-cluster-hcp/main.tf
@@ -22,7 +22,7 @@ locals {
     operator_role_prefix = var.operator_role_prefix,
     oidc_config_id       = var.oidc_config_id
   }
-  aws_account_arn = var.aws_account_arn == null ? data.aws_caller_identity.current[0].arn : var.aws_account_arn
+  aws_account_arn = var.aws_account_arn == null ? data.aws_iam_session_context.current[0].issuer_arn : var.aws_account_arn
   create_admin_user = var.create_admin_user
   admin_credentials = var.admin_credentials_username == null && var.admin_credentials_password == null ? (
     null
@@ -144,6 +144,12 @@ resource "rhcs_hcp_default_ingress" "default_ingress" {
 data "aws_caller_identity" "current" {
   count = var.aws_account_id == null || var.aws_account_arn == null ? 1 : 0
 }
+
+data "aws_iam_session_context" "current" {
+  count = var.aws_account_id == null || var.aws_account_arn == null ? 1 : 0
+  arn = try(data.aws_caller_identity.current[0].arn, "")
+}
+
 
 data "aws_region" "current" {
   count = var.aws_region == null ? 1 : 0


### PR DESCRIPTION
Fix for [https://github.com/terraform-redhat/terraform-rhcs-rosa-hcp/issues/64](https://github.com/terraform-redhat/terraform-rhcs-rosa-hcp/issues/64)

Correct calculation of issuer_arn, so that it isn't using ephemeral session and instead uses the correct static arn value.