### PR TITLE
OCM-16745 | fix: Apply bucket policy after public access settings

### DIFF
--- a/modules/oidc-config-and-provider/main.tf
+++ b/modules/oidc-config-and-provider/main.tf
@@ -58,9 +58,10 @@ data "aws_iam_policy_document" "allow_access_from_another_account" {
 }
 
 resource "aws_s3_bucket_policy" "allow_access_from_another_account" {
-  count  = var.managed ? 0 : 1
-  bucket = aws_s3_bucket.s3_bucket[count.index].id
-  policy = data.aws_iam_policy_document.allow_access_from_another_account[count.index].json
+  depends_on = [aws_s3_bucket_public_access_block.public_access_block]
+  count      = var.managed ? 0 : 1
+  bucket     = aws_s3_bucket.s3_bucket[count.index].id
+  policy     = data.aws_iam_policy_document.allow_access_from_another_account[count.index].json
 }
 
 resource "rhcs_rosa_oidc_config_input" "oidc_input" {


### PR DESCRIPTION
Updating the HCP `oidc-config-and-provider` submodule to use the same modules for configuring S3 buckets and secret manager that we're already using in the classic version of the submodule (https://github.com/terraform-redhat/terraform-rhcs-rosa-classic/blob/main/modules/oidc-config-and-provider/main.tf#L21). This seems to fix a weird issue that's appeared in the TF pipeline since we migrated AWS accounts