### PR TITLE
A fix for "account-iam-resources" sub module" and a small update to replace deprecated aws provider attribute with the latest one.

### DIFF
--- a/modules/account-iam-resources/main.tf
+++ b/modules/account-iam-resources/main.tf
@@ -68,7 +68,6 @@ resource "aws_iam_role_policy_attachment" "account_role_policy_attachment" {
 }
 
 resource "random_string" "default_random" {
-  count = 1
   length  = 4
   special = false
   upper   = false

--- a/modules/account-iam-resources/main.tf
+++ b/modules/account-iam-resources/main.tf
@@ -69,7 +69,7 @@ resource "aws_iam_role_policy_attachment" "account_role_policy_attachment" {
 
 resource "random_string" "default_random" {
  #  count = (var.account_role_prefix != null && var.account_role_prefix != "") ? 0 : 1
-  count = 0
+  count = 1
   length  = 4
   special = false
   upper   = false

--- a/modules/account-iam-resources/main.tf
+++ b/modules/account-iam-resources/main.tf
@@ -28,7 +28,7 @@ locals {
   account_role_prefix_valid = (var.account_role_prefix != null && var.account_role_prefix != "") ? (
     var.account_role_prefix
     ) : (
-    "account-role-${random_string.default_random[0].result}"
+     "account-role-${random_string.default_random[0].result}"
   )
 }
 
@@ -69,6 +69,7 @@ resource "aws_iam_role_policy_attachment" "account_role_policy_attachment" {
 
 resource "random_string" "default_random" {
  #  count = (var.account_role_prefix != null && var.account_role_prefix != "") ? 0 : 1
+  count = 0
   length  = 4
   special = false
   upper   = false

--- a/modules/account-iam-resources/main.tf
+++ b/modules/account-iam-resources/main.tf
@@ -28,7 +28,7 @@ locals {
   account_role_prefix_valid = (var.account_role_prefix != null && var.account_role_prefix != "") ? (
     var.account_role_prefix
     ) : (
-     "account-role-${random_string.default_random[0].result}"
+     "account-role-${random_string.default_random.result}"
   )
 }
 
@@ -68,7 +68,6 @@ resource "aws_iam_role_policy_attachment" "account_role_policy_attachment" {
 }
 
 resource "random_string" "default_random" {
- #  count = (var.account_role_prefix != null && var.account_role_prefix != "") ? 0 : 1
   count = 1
   length  = 4
   special = false

--- a/modules/account-iam-resources/main.tf
+++ b/modules/account-iam-resources/main.tf
@@ -68,8 +68,7 @@ resource "aws_iam_role_policy_attachment" "account_role_policy_attachment" {
 }
 
 resource "random_string" "default_random" {
-  count = (var.account_role_prefix != null && var.account_role_prefix != "") ? 0 : 1
-
+ #  count = (var.account_role_prefix != null && var.account_role_prefix != "") ? 0 : 1
   length  = 4
   special = false
   upper   = false

--- a/modules/oidc-config-and-provider/main.tf
+++ b/modules/oidc-config-and-provider/main.tf
@@ -66,7 +66,8 @@ resource "aws_s3_bucket_policy" "allow_access_from_another_account" {
 resource "rhcs_rosa_oidc_config_input" "oidc_input" {
   count = var.managed ? 0 : 1
 
-  region = data.aws_region.current.name
+  # region = data.aws_region.current.name
+  region = data.aws_region.current.region
 }
 
 resource "aws_secretsmanager_secret" "secret" {

--- a/modules/oidc-config-and-provider/main.tf
+++ b/modules/oidc-config-and-provider/main.tf
@@ -66,7 +66,6 @@ resource "aws_s3_bucket_policy" "allow_access_from_another_account" {
 resource "rhcs_rosa_oidc_config_input" "oidc_input" {
   count = var.managed ? 0 : 1
 
-  # region = data.aws_region.current.name
   region = data.aws_region.current.region
 }
 

--- a/modules/rosa-cluster-hcp/main.tf
+++ b/modules/rosa-cluster-hcp/main.tf
@@ -42,7 +42,7 @@ resource "rhcs_cluster_rosa_hcp" "rosa_hcp_cluster" {
     },
     var.properties
   )
-  cloud_region   = var.aws_region == null ? data.aws_region.current[0].name : var.aws_region
+  cloud_region   = var.aws_region == null ? data.aws_region.current[0].region : var.aws_region
   aws_account_id = local.aws_account_id
   aws_billing_account_id = var.aws_billing_account_id == null || var.aws_billing_account_id == "" ? (
     local.aws_account_id


### PR DESCRIPTION
1) Fix.

I've got the following error when I run my old terraform script which refers to rhcs module even though I hadn't changed anything. 
╷
│ Error: Invalid count argument
│
│   on .terraform/modules/rosa-hcp/modules/account-iam-resources/main.tf line 71, in resource "random_string" "default_random":
│   71:   count = (var.account_role_prefix != null && var.account_role_prefix != "") ? 0 : 1
│
│ The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot predict    
│ how many instances will be created. To work around this, use the -target argument to first apply only the resources    
│ that the count depends on.
╵
$ 

My root module passes a random_string to initialize the "account_role_prefix" variable, but it causes the error in a resource in "account-iam-resources" sub module. 

The reason for this error was that  [var.account_role_prefix != ""]  check added to the resource "random_string.default_random".
random_string is (known after apply) value. (known after apply) can't be compared with "" string at the terraform plan phase.  
And I believe this change is also affecting when you specify a random_string for the cluster_name variable in root module because it copies to "account_role_prefix" variable within the rhcs module. 

As I checked the "random_string.default_random" attribute, the random value is only referred once at most from the main.tf file with fixed index [0]. There is no reference other than that.  So, the count value is not actually used at the moment. 

As well as that, the following part itself where the count is generated, which is causing the issue, seems unnecessary after I took a look at the rhcs modules.

 count = (var.account_role_prefix != null && var.account_role_prefix != "") ? 0 : 1

I guess the check was implemented when it was copied and pasted from other resources like "aws_iam_role.account_role" 
At the moment, I thought the count in random_string.default_random would be better to be removed to prevent people from confusion in the future.   

2) update deprecated aws attribute

I've got the error below so I replaced old aws attribute with the latest one.
╷
│ Warning: Deprecated attribute
│
│   on .terraform/modules/rosa-hcp/modules/oidc-config-and-provider/main.tf line 69, in resource "rhcs_rosa_oidc_config_input" "oidc_input":
│   69:   region = data.aws_region.current.name
│
│ The attribute "name" is deprecated. Refer to the provider documentation for details.
│



