### PR TITLE
Make 'additional_security_group_ids' optional

### DIFF
--- a/examples/rosa-hcp-private/README.md
+++ b/examples/rosa-hcp-private/README.md
@@ -141,8 +141,8 @@ module "bastion_host" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | n/a | `string` | n/a | yes |
-| <a name="input_openshift_version"></a> [openshift\_version](#input\_openshift\_version) | n/a | `string` | `"4.16.3"` | no |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster. After the creation of the resource, it is not possible to update the attribute value. | `string` | n/a | yes |
+| <a name="input_openshift_version"></a> [openshift\_version](#input\_openshift\_version) | The required version of Red Hat OpenShift for the cluster, for example '4.1.0'. If version is greater than the currently running version, an upgrade will be scheduled. | `string` | `"4.19.3"` | no |
 
 ## Outputs
 

--- a/examples/rosa-hcp-public-unmanaged-oidc/README.md
+++ b/examples/rosa-hcp-public-unmanaged-oidc/README.md
@@ -99,8 +99,8 @@ module "vpc" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | n/a | `string` | n/a | yes |
-| <a name="input_openshift_version"></a> [openshift\_version](#input\_openshift\_version) | n/a | `string` | `"4.16.3"` | no |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster. After the creation of the resource, it is not possible to update the attribute value. | `string` | n/a | yes |
+| <a name="input_openshift_version"></a> [openshift\_version](#input\_openshift\_version) | The required version of Red Hat OpenShift for the cluster, for example '4.1.0'. If version is greater than the currently running version, an upgrade will be scheduled. | `string` | `"4.19.3"` | no |
 
 ## Outputs
 

--- a/examples/rosa-hcp-public-with-multiple-machinepools-and-idps/README.md
+++ b/examples/rosa-hcp-public-with-multiple-machinepools-and-idps/README.md
@@ -216,7 +216,7 @@ module "vpc" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster. After the creation of the resource, it is not possible to update the attribute value. | `string` | n/a | yes |
-| <a name="input_openshift_version"></a> [openshift\_version](#input\_openshift\_version) | The required version of Red Hat OpenShift for the cluster, for example '4.1.0'. If version is greater than the currently running version, an upgrade will be scheduled. | `string` | `"4.16.3"` | no |
+| <a name="input_openshift_version"></a> [openshift\_version](#input\_openshift\_version) | The required version of Red Hat OpenShift for the cluster, for example '4.1.0'. If version is greater than the currently running version, an upgrade will be scheduled. | `string` | `"4.19.3"` | no |
 
 ## Outputs
 

--- a/examples/rosa-hcp-public/README.md
+++ b/examples/rosa-hcp-public/README.md
@@ -98,8 +98,8 @@ module "vpc" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | n/a | `string` | n/a | yes |
-| <a name="input_openshift_version"></a> [openshift\_version](#input\_openshift\_version) | n/a | `string` | `"4.16.3"` | no |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster. After the creation of the resource, it is not possible to update the attribute value. | `string` | n/a | yes |
+| <a name="input_openshift_version"></a> [openshift\_version](#input\_openshift\_version) | The required version of Red Hat OpenShift for the cluster, for example '4.1.0'. If version is greater than the currently running version, an upgrade will be scheduled. | `string` | `"4.19.3"` | no |
 
 ## Outputs
 

--- a/modules/machine-pool/README.md
+++ b/modules/machine-pool/README.md
@@ -61,7 +61,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_auto_repair"></a> [auto\_repair](#input\_auto\_repair) | Configures auto repair option for the pool. | `bool` | `true` | no |
 | <a name="input_autoscaling"></a> [autoscaling](#input\_autoscaling) | Configures autoscaling for the pool. | <pre>object({<br>    enabled      = bool<br>    min_replicas = number<br>    max_replicas = number<br>  })</pre> | <pre>{<br>  "enabled": false,<br>  "max_replicas": null,<br>  "min_replicas": null<br>}</pre> | no |
-| <a name="input_aws_node_pool"></a> [aws\_node\_pool](#input\_aws\_node\_pool) | Configures aws settings for the pool. | <pre>object({<br>    instance_type = string<br>    tags = map(string)<br>    additional_security_group_ids = list(string)<br>  })</pre> | n/a | yes |
+| <a name="input_aws_node_pool"></a> [aws\_node\_pool](#input\_aws\_node\_pool) | Configures aws settings for the pool. | <pre>object({<br>    instance_type                 = string<br>    tags                          = map(string)<br>    additional_security_group_ids = optional(list(string))<br>  })</pre> | n/a | yes |
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | Identifier of the cluster. | `string` | n/a | yes |
 | <a name="input_ignore_deletion_error"></a> [ignore\_deletion\_error](#input\_ignore\_deletion\_error) | Ignore machine pool deletion error. Assists when cluster resource is managed within the same file for the destroy use case | `bool` | `false` | no |
 | <a name="input_kubelet_configs"></a> [kubelet\_configs](#input\_kubelet\_configs) | Name of the kubelet configs to attach to this machine pool. The kubelet configs must already exist | `string` | `null` | no |

--- a/modules/machine-pool/variables.tf
+++ b/modules/machine-pool/variables.tf
@@ -55,9 +55,9 @@ variable "autoscaling" {
 
 variable "aws_node_pool" {
   type = object({
-    instance_type = string
-    tags = map(string)
-    additional_security_group_ids = list(string)
+    instance_type                 = string
+    tags                          = map(string)
+    additional_security_group_ids = optional(list(string))
   })
   nullable    = false
   description = "Configures aws settings for the pool."


### PR DESCRIPTION
As described in the issue in the reference down below, the creation of a custom worker pool fails when there is no 'additional_security_group_ids' specified, when it points to an empty list or when the list contains only an empty string (as in the examples in this repository).

The Red Hat's terraform-provider-rhcs provider [1] defines this attribute as optional:

    "additional_security_group_ids": {
        "type": [
          "list",
          "string"
        ],
        "description": "Additional security group ids. After the creation of the resource, it is not possible to update the attribute value.",
        "description_kind": "plain",
        "optional": true
      }

This commit changes the 'aws_node_pool' variable to reflect the optional nature of this attribute; after applying this change, the custom pool creation is successful.

[1] https://github.com/terraform-redhat/terraform-provider-rhcs

Fixes #78