### PR TITLE
Changing data source aws_region.current.name to aws_region.current.re…

### DIFF
--- a/modules/oidc-config-and-provider/main.tf
+++ b/modules/oidc-config-and-provider/main.tf
@@ -67,7 +67,7 @@ resource "aws_s3_bucket_policy" "allow_access_from_another_account" {
 resource "rhcs_rosa_oidc_config_input" "oidc_input" {
   count = var.managed ? 0 : 1
 
-  region = data.aws_region.current.name
+  region = data.aws_region.current.region
 }
 
 resource "aws_secretsmanager_secret" "secret" {

--- a/modules/rosa-cluster-hcp/main.tf
+++ b/modules/rosa-cluster-hcp/main.tf
@@ -42,7 +42,7 @@ resource "rhcs_cluster_rosa_hcp" "rosa_hcp_cluster" {
     },
     var.properties
   )
-  cloud_region   = var.aws_region == null ? data.aws_region.current[0].name : var.aws_region
+  cloud_region   = var.aws_region == null ? data.aws_region.current[0].region : var.aws_region
   aws_account_id = local.aws_account_id
   aws_billing_account_id = var.aws_billing_account_id == null || var.aws_billing_account_id == "" ? (
     local.aws_account_id

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -20,7 +20,7 @@ resource "aws_vpc" "vpc" {
 
 resource "aws_vpc_endpoint" "s3" {
   vpc_id       = aws_vpc.vpc.id
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
 }
 
 resource "aws_subnet" "public_subnet" {


### PR DESCRIPTION
…gion as name is deprecated - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region