### PR TITLE
Support ROSA GovCloud HCP clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ We recommend you install the following CLI tools:
 | [null_resource.validations](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [rhcs_dns_domain.dns_domain](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/resources/dns_domain) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,13 @@
+data "aws_partition" "current" {}
+
 locals {
   path                 = coalesce(var.path, "/")
   account_role_prefix  = coalesce(var.account_role_prefix, "${var.cluster_name}-account")
   operator_role_prefix = coalesce(var.operator_role_prefix, "${var.cluster_name}-operator")
   sts_roles = {
-    installer_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${local.account_role_prefix}-HCP-ROSA-Installer-Role",
-    support_role_arn   = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${local.account_role_prefix}-HCP-ROSA-Support-Role",
-    worker_role_arn    = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${local.account_role_prefix}-HCP-ROSA-Worker-Role"
+    installer_role_arn = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${local.account_role_prefix}-HCP-ROSA-Installer-Role",
+    support_role_arn   = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${local.account_role_prefix}-HCP-ROSA-Support-Role",
+    worker_role_arn    = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${local.account_role_prefix}-HCP-ROSA-Worker-Role"
   }
 }
 

--- a/modules/account-iam-resources/main.tf
+++ b/modules/account-iam-resources/main.tf
@@ -4,22 +4,22 @@ locals {
     {
       role_name            = "HCP-ROSA-Installer"
       role_type            = "installer"
-      policy_details       = "arn:aws:iam::aws:policy/service-role/ROSAInstallerPolicy"
+      policy_details       = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/ROSAInstallerPolicy"
       principal_type       = "AWS"
       principal_identifier = "arn:${data.aws_partition.current.partition}:iam::${data.rhcs_info.current.ocm_aws_account_id}:role/RH-Managed-OpenShift-Installer"
     },
     {
-      role_name      = "HCP-ROSA-Support"
-      role_type      = "support"
-      policy_details = "arn:aws:iam::aws:policy/service-role/ROSASRESupportPolicy"
-      principal_type = "AWS"
+      role_name            = "HCP-ROSA-Support"
+      role_type            = "support"
+      policy_details       = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/ROSASRESupportPolicy"
+      principal_type       = "AWS"
       // This is a SRE RH Support role which is used to assume this support role
       principal_identifier = data.rhcs_hcp_policies.all_policies.account_role_policies["sts_support_rh_sre_role"]
     },
     {
       role_name            = "HCP-ROSA-Worker"
       role_type            = "instance_worker"
-      policy_details       = "arn:aws:iam::aws:policy/service-role/ROSAWorkerInstancePolicy"
+      policy_details       = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/ROSAWorkerInstancePolicy"
       principal_type       = "Service"
       principal_identifier = "ec2.amazonaws.com"
     },

--- a/modules/operator-roles/README.md
+++ b/modules/operator-roles/README.md
@@ -63,6 +63,7 @@ No modules.
 | [time_sleep.role_resources_propagation](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.custom_trust_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 

--- a/modules/operator-roles/main.tf
+++ b/modules/operator-roles/main.tf
@@ -1,59 +1,61 @@
+data "aws_partition" "current" {}
+
 locals {
   operator_roles_properties = [
     {
       operator_name      = "installer-cloud-credentials"
       operator_namespace = "openshift-image-registry"
       role_name          = "openshift-image-registry-installer-cloud-credentials"
-      policy_details     = "arn:aws:iam::aws:policy/service-role/ROSAImageRegistryOperatorPolicy"
+      policy_details     = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/ROSAImageRegistryOperatorPolicy"
       service_accounts   = ["system:serviceaccount:openshift-image-registry:cluster-image-registry-operator", "system:serviceaccount:openshift-image-registry:registry"]
     },
     {
       operator_name      = "cloud-credentials"
       operator_namespace = "openshift-ingress-operator"
       role_name          = "openshift-ingress-operator-cloud-credentials"
-      policy_details     = "arn:aws:iam::aws:policy/service-role/ROSAIngressOperatorPolicy"
+      policy_details     = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/ROSAIngressOperatorPolicy"
       service_accounts   = ["system:serviceaccount:openshift-ingress-operator:ingress-operator"]
     },
     {
       operator_name      = "ebs-cloud-credentials"
       operator_namespace = "openshift-cluster-csi-drivers"
       role_name          = "openshift-cluster-csi-drivers-ebs-cloud-credentials"
-      policy_details     = "arn:aws:iam::aws:policy/service-role/ROSAAmazonEBSCSIDriverOperatorPolicy"
+      policy_details     = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/ROSAAmazonEBSCSIDriverOperatorPolicy"
       service_accounts   = ["system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator", "system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-controller-sa"]
     },
     {
       operator_name      = "cloud-credentials"
       operator_namespace = "openshift-cloud-network-config-controller"
       role_name          = "openshift-cloud-network-config-controller-cloud-credentials"
-      policy_details     = "arn:aws:iam::aws:policy/service-role/ROSACloudNetworkConfigOperatorPolicy"
+      policy_details     = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/ROSACloudNetworkConfigOperatorPolicy"
       service_accounts   = ["system:serviceaccount:openshift-cloud-network-config-controller:cloud-network-config-controller"]
     },
     {
       operator_name      = "kube-controller-manager"
       operator_namespace = "kube-system"
       role_name          = "kube-system-kube-controller-manager"
-      policy_details     = "arn:aws:iam::aws:policy/service-role/ROSAKubeControllerPolicy"
+      policy_details     = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/ROSAKubeControllerPolicy"
       service_accounts   = ["system:serviceaccount:kube-system:kube-controller-manager"]
     },
     {
       operator_name      = "capa-controller-manager"
       operator_namespace = "kube-system"
       role_name          = "kube-system-capa-controller-manager"
-      policy_details     = "arn:aws:iam::aws:policy/service-role/ROSANodePoolManagementPolicy"
+      policy_details     = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/ROSANodePoolManagementPolicy"
       service_accounts   = ["system:serviceaccount:kube-system:capa-controller-manager"]
     },
     {
       operator_name      = "control-plane-operator"
       operator_namespace = "kube-system"
       role_name          = "kube-system-control-plane-operator"
-      policy_details     = "arn:aws:iam::aws:policy/service-role/ROSAControlPlaneOperatorPolicy"
+      policy_details     = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/ROSAControlPlaneOperatorPolicy"
       service_accounts   = ["system:serviceaccount:kube-system:control-plane-operator"]
     },
     {
       operator_name      = "kms-provider"
       operator_namespace = "kube-system"
       role_name          = "kube-system-kms-provider"
-      policy_details     = "arn:aws:iam::aws:policy/service-role/ROSAKMSProviderPolicy"
+      policy_details     = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/ROSAKMSProviderPolicy"
       service_accounts   = ["system:serviceaccount:kube-system:kms-provider"]
     },
   ]
@@ -83,7 +85,7 @@ data "aws_iam_policy_document" "custom_trust_policy" {
     actions = ["sts:AssumeRoleWithWebIdentity"]
     principals {
       type        = "Federated"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${var.oidc_endpoint_url}"]
+      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${var.oidc_endpoint_url}"]
     }
     condition {
       test     = "StringEquals"

--- a/modules/rosa-cluster-hcp/README.md
+++ b/modules/rosa-cluster-hcp/README.md
@@ -39,14 +39,14 @@ module "rosa_cluster_hcp" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.38.0 |
-| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | >= 1.6.8 |
+| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | >= 1.7.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.38.0 |
-| <a name="provider_rhcs"></a> [rhcs](#provider\_rhcs) | >= 1.6.8 |
+| <a name="provider_rhcs"></a> [rhcs](#provider\_rhcs) | >= 1.7.1 |
 
 ## Modules
 
@@ -61,6 +61,7 @@ No modules.
 | [rhcs_hcp_default_ingress.default_ingress](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/resources/hcp_default_ingress) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_subnet.provided_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 

--- a/modules/rosa-cluster-hcp/versions.tf
+++ b/modules/rosa-cluster-hcp/versions.tf
@@ -7,7 +7,7 @@ terraform {
       version = ">= 5.38.0"
     }
     rhcs = {
-      version = ">= 1.6.8"
+      version = ">= 1.7.1"
       source  = "terraform-redhat/rhcs"
     }
   }


### PR DESCRIPTION
Before this commit, the modules made two assumptions which prevented creation of HCP clusters on ROSA GovCloud:

1. ARN formats hard-coded the AWS partition
2. The `rhcs_cluster_rosa_hcp` module always set a billing account ID, which should always be empty for GovCloud HCP clusters.

This commit makes ARN partition segments dynamic with regards to the current AWS account, and sets a `null` billing account ID when targeting GovCloud. The result is HCP clusters can be successfully created on ROSA GovCloud.

Support for GovCloud requires `terraform-provider-rhcs >=v1.7.1`.