### PR TITLE
OCM-00000 | chore: update OWNERS approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,15 +1,11 @@
 approvers:
-- bardielle
-- sagidayan
-- nirarg
-- enriquebelarte
-- gdbranco
-- ciaranRoche
-- robpblake
-- hunterkepley
-- davidleerh
-- philipwu08
+- olucasfreitas
 - jerichokeyne
 - amandahla
-- olucasfreitas
+- BraeTroutman
+- marcolan018
+- gdbranco
+- robpblake
+- davidleerh
 - willkutler
+- red-hat-konflux[bot]


### PR DESCRIPTION
## Summary
- Update the `OWNERS` approver list to the requested current maintainers.
- Add `red-hat-konflux[bot]` and remove approvers that should no longer be listed.

## Test plan
- [x] Verified `OWNERS` matches the requested approver list exactly.
- [x] Ran `git diff --check upstream/main...HEAD`.
- [ ] `make verify` fails in a clean worktree due existing Terraform registry DNS errors and missing example paths; this PR does not change Terraform code.