### PR TITLE
OCM-23911 | chore: add coderabbit configuration file

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,29 +1,5 @@
----
-# CodeRabbit — terraform-rhcs-rosa-hcp (ROSA HCP only)
-# https://docs.coderabbit.ai/
-# Canonical policy: .cursor/rules/rosa-hcp-terraform.mdc, AGENTS.md,
-#   CONTRIBUTING.md (avoid duplicating long rule text here).
-
-language: en-US
-early_access: false
-
+inheritance: true
 reviews:
-  profile: chill
-  request_changes_workflow: true
-  high_level_summary: true
-  poem: false
-  review_status: true
-  collapse_walkthrough: false
-
-  auto_review:
-    enabled: true
-    drafts: false
-    base_branches:
-      - main
-    ignore_title_keywords:
-      - WIP
-      - "Do Not Merge"
-
   path_filters:
     - "!**/.terraform/**"
     - "!**/terraform.tfstate*"
@@ -88,10 +64,6 @@ reviews:
         CI changes affect every PR: keep **make verify**, lint, and doc
         generation behavior consistent with **CONTRIBUTING.md**; avoid
         weakening checks without an explicit rationale in the PR.
-
-  abort_on_close: true
-  auto_title_placeholder: "@coderabbitai"
-
   tools:
     checkov:
       enabled: true
@@ -111,12 +83,3 @@ reviews:
       enabled: true
     yamllint:
       enabled: true
-
-chat:
-  auto_reply: true
-
-knowledge_base:
-  learnings:
-    scope: auto
-  issues:
-    scope: auto

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,120 @@
+---
+# CodeRabbit — terraform-rhcs-rosa-hcp (ROSA HCP only)
+# https://docs.coderabbit.ai/
+# Canonical policy: .cursor/rules/rosa-hcp-terraform.mdc, AGENTS.md,
+#   CONTRIBUTING.md (avoid duplicating long rule text here).
+
+language: en-US
+early_access: false
+
+reviews:
+  profile: chill
+  request_changes_workflow: true
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+    ignore_title_keywords:
+      - WIP
+      - "Do Not Merge"
+
+  path_filters:
+    - "!**/.terraform/**"
+    - "!**/terraform.tfstate*"
+
+  path_instructions:
+    - path: "**/*.tf"
+      instructions: |
+        **ROSA HCP only** — not ROSA Classic (see terraform-rhcs-rosa-classic).
+        **rhcs** registry schemas are authoritative; do not invent attributes.
+        Root **versions.tf** sets minimum **rhcs** / **aws** / other providers
+        for the **entire** tree; raise root when any submodule raises a floor.
+        AWS-only work must match **Module scope** in
+        .cursor/rules/rosa-hcp-terraform.mdc. Variables: snake_case;
+        **sensitive** on secrets; no long-lived keys in HCL. Finer points
+        (validation, import-safe count/for_each): see **AGENTS.md** and
+        .cursor/rules.
+
+    - path: "modules/**"
+      instructions: |
+        Submodule changes affect root, **examples/**, and downstream users.
+
+        1. **Breaking changes:** No silent renames/retypes of variables or
+           outputs; migration plan or explicit PR callout (AGENTS.md).
+
+        2. **Provider floor:** **required_providers** changes → update root
+           **versions.tf** for the whole module tree.
+
+        3. **IAM / STS / OIDC / IRSA:** Least privilege; link non-obvious
+           cross-account or shared-VPC patterns to official ROSA HCP docs.
+
+        4. **Ordering:** IAM/STS eventual consistency — **depends_on** /
+           waits / preconditions where immediate effect is assumed.
+
+        5. **Tests / examples:** Update **modules/*/tests/*.tftest.hcl** and
+           keep **make verify** green for touched **examples/**.
+
+        6. **modules/rosa-cluster-hcp:** **rhcs_cluster_rosa_hcp** (and
+           related rhcs resources) — match provider docs; document minimum
+           OpenShift version for version-gated features.
+
+        7. **modules/shared-vpc-resources:** RAM, endpoints, IAM trust per
+           shared VPC docs; prefer narrow bindings over broad IAM.
+
+    - path: "examples/**/*.tf"
+      instructions: |
+        **make verify** (init + validate per example) must stay passing.
+        No embedded credentials; follow existing auth patterns.
+
+    - path: "**/*.tftest.hcl"
+      instructions: |
+        Per **CONTRIBUTING.md** / **AGENTS.md**: mocks where the repo does;
+        branch on booleans → cover both outcomes. Tests live under
+        **modules/<name>/tests/** (see **make unit-tests** / README).
+
+    - path: "scripts/**"
+      instructions: |
+        No secret leakage. Behavior must stay aligned with **CONTRIBUTING.md**
+        (fmt, terraform-docs, verify-gen, verify).
+
+    - path: ".github/workflows/**"
+      instructions: |
+        CI changes affect every PR: keep **make verify**, lint, and doc
+        generation behavior consistent with **CONTRIBUTING.md**; avoid
+        weakening checks without an explicit rationale in the PR.
+
+  abort_on_close: true
+  auto_title_placeholder: "@coderabbitai"
+
+  tools:
+    trivy:
+      enabled: true
+    checkov:
+      enabled: true
+    hadolint:
+      enabled: true
+    shellcheck:
+      enabled: true
+    tflint:
+      enabled: true
+    yamllint:
+      enabled: true
+    markdownlint:
+      enabled: false
+    golangci-lint:
+      enabled: false
+
+chat:
+  auto_reply: true
+
+knowledge_base:
+  learnings:
+    scope: auto
+  issues:
+    scope: auto

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -93,22 +93,24 @@ reviews:
   auto_title_placeholder: "@coderabbitai"
 
   tools:
-    trivy:
-      enabled: true
     checkov:
       enabled: true
+    gitleaks:
+      enabled: true
+    golangci-lint:
+      enabled: false
     hadolint:
       enabled: true
+    markdownlint:
+      enabled: false
     shellcheck:
       enabled: true
     tflint:
       enabled: true
+    trivy:
+      enabled: true
     yamllint:
       enabled: true
-    markdownlint:
-      enabled: false
-    golangci-lint:
-      enabled: false
 
 chat:
   auto_reply: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# terraform-docs.sh pinned binary cache (version from Dockerfile)
+.terraform-docs-cache/
+
 # Local .terraform directories
 **/.terraform/*
 **/.terraform.lock.hcl

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,17 @@
+# Gitleaks — https://github.com/gitleaks/gitleaks/blob/master/README.md
+# Used by CodeRabbit when gitleaks is enabled (.coderabbit.yaml) and by CI/local
+# `gitleaks detect`. Extends upstream default rules.
+#
+# **/*.tftest.hcl harnesses may use mocks/placeholders — not live credentials.
+
+title = "terraform-rhcs-rosa-hcp"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Terraform CLI test configs may contain mock tokens/placeholders."
+paths = [
+  # e.g. modules/*/tests/*.tftest.hcl
+  '''\.tftest''',
+]

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,5 @@
+# Misconfiguration IDs to skip — see https://trivy.dev/latest/docs/configuration/filtering/
+# Prefer `#trivy:ignore:<ID>` on Terraform resources; use this file when required (e.g. Dockerfile).
+
+# Root Dockerfile: tooling image installs yum/terraform/aws/rosa/terraform-docs as root; no non-root USER by design.
+DS-0002

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,6 @@ When **`trivy config`** reports a **misconfiguration** (check IDs like **`AWS-01
 1. **Prefer fixing** the HCL/Dockerfile (least privilege, encryption, IMDSv2, non-root user, etc.).
 2. If an ignore is required, add **`#trivy:ignore:<id>`** on the line **immediately above** the Terraform resource or Dockerfile instruction, with a **short `#` comment** on the same line or the line above explaining why (narrow scope).
 3. Use **`.trivyignore`** only when inline suppression is not possible — one ID per line with a **`#` justification** above each.
-4. **Dockerfile `DS-0002`:** Inline `#trivy:ignore` is not reliably applied by Trivy for this rule; prefer **`USER` with a non-root account** after root-only install steps (see root `Dockerfile`).
 
 ## Critical Module Guardrails
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,17 @@ Useful skills for this codebase:
 - Use **`sensitive`** on variables and outputs where values must not appear in logs or casual `terraform show` output; avoid echoing secrets in `local` values used only for debugging. Passthrough outputs (**`module.*` → root output**) must match submodule sensitivity—see **Security** in [`.cursor/rules/rosa-hcp-terraform.mdc`](.cursor/rules/rosa-hcp-terraform.mdc).
 - Do not add logging, outputs, or comments that expose credentials or session tokens.
 
+## Trivy (IaC misconfiguration)
+
+Repo config: root **`trivy.yaml`** (severity, scanners, skips; includes **`examples/`**). CodeRabbit may run Trivy when enabled in **`.coderabbit.yaml`**. References: [Trivy config file](https://trivy.dev/latest/docs/references/configuration/config-file/), [filtering / ignores](https://trivy.dev/latest/docs/configuration/filtering/).
+
+When **`trivy config`** reports a **misconfiguration** (check IDs like **`AWS-0104`**, **`DS-0002`** — not CVE vulnerability rows from **`trivy fs`** vuln scans):
+
+1. **Prefer fixing** the HCL/Dockerfile (least privilege, encryption, IMDSv2, non-root user, etc.).
+2. If an ignore is required, add **`#trivy:ignore:<id>`** on the line **immediately above** the Terraform resource or Dockerfile instruction, with a **short `#` comment** on the same line or the line above explaining why (narrow scope).
+3. Use **`.trivyignore`** only when inline suppression is not possible — one ID per line with a **`#` justification** above each.
+4. **Dockerfile `DS-0002`:** Inline `#trivy:ignore` is not reliably applied by Trivy for this rule; prefer **`USER` with a non-root account** after root-only install steps (see root `Dockerfile`).
+
 ## Critical Module Guardrails
 
 - Breaking Changes: Do NOT change existing variable names or types without a migration plan (refactor-module skill).

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,7 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     ./aws/install -i /usr/local/aws-cli -b /usr/local/bin && rm awscliv2.zip && rm -r aws/
 RUN curl -sL "https://mirror.openshift.com/pub/cgw/rosa/latest/rosa-linux.tar.gz" -o "rosa.tar.gz" && \
     tar xfvz rosa.tar.gz --no-same-owner && mv rosa /usr/local/bin/rosa && rm rosa.tar.gz
-# Added terraform-docs following the instructions here: https://terraform-docs.io/user-guide/installation/
-# renovate: datasource=github-releases depName=terraform-docs/terraform-docs extractVersion=^v(?<version>.*)$
 ARG TERRAFORM_DOCS_VERSION=0.22.0
 RUN curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/v${TERRAFORM_DOCS_VERSION}/terraform-docs-v${TERRAFORM_DOCS_VERSION}-$(uname)-amd64.tar.gz && \
     tar -xzf terraform-docs.tar.gz terraform-docs && chmod +x terraform-docs && \
     mv terraform-docs /usr/local/bin/terraform-docs && rm terraform-docs.tar.gz
-# Installers above run as root; run default container process as non-root (Trivy DS-0002).
-RUN useradd -r -u 10001 -m -d /home/moduleuser moduleuser && \
-    chown -R moduleuser:moduleuser /app
-USER moduleuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,7 @@ ARG TERRAFORM_DOCS_VERSION=0.22.0
 RUN curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/v${TERRAFORM_DOCS_VERSION}/terraform-docs-v${TERRAFORM_DOCS_VERSION}-$(uname)-amd64.tar.gz && \
     tar -xzf terraform-docs.tar.gz terraform-docs && chmod +x terraform-docs && \
     mv terraform-docs /usr/local/bin/terraform-docs && rm terraform-docs.tar.gz
+# Installers above run as root; run default container process as non-root (Trivy DS-0002).
+RUN useradd -r -u 10001 -m -d /home/moduleuser moduleuser && \
+    chown -R moduleuser:moduleuser /app
+USER moduleuser

--- a/modules/bastion-host/main.tf
+++ b/modules/bastion-host/main.tf
@@ -27,6 +27,7 @@ data "http" "myip" {
   url = "https://ipv4.icanhazip.com"
 }
 
+#trivy:ignore:aws-0104 # Optional bastion: egress 0.0.0.0/0 and ::/0 for package updates and outbound access.
 resource "aws_security_group" "bastion_host_ingress" {
   name   = "${var.prefix}-bastion-security-group"
   vpc_id = var.vpc_id
@@ -75,6 +76,8 @@ data "aws_ami" "rhel9" {
   owners = [local.redhat_aws_account]
 }
 
+#trivy:ignore:aws-0028 # Optional bastion: IMDSv2 optional; tighten with metadata_options if policy requires.
+#trivy:ignore:aws-0131 # Optional bastion: enforce encryption via AMI or root_block_device when hardening.
 resource "aws_instance" "bastion_host" {
   count                       = length(var.subnet_ids)
   ami                         = var.ami_id != null ? var.ami_id : data.aws_ami.rhel9[0].id

--- a/modules/oidc-config-and-provider/main.tf
+++ b/modules/oidc-config-and-provider/main.tf
@@ -18,6 +18,7 @@ resource "aws_iam_openid_connect_provider" "oidc_provider" {
   thumbprint_list = [rhcs_rosa_oidc_config.oidc_config.thumbprint]
 }
 
+#trivy:ignore:aws-0132 # Unmanaged OIDC: discovery bucket; default SSE-S3; CMK optional for this pattern.
 resource "aws_s3_bucket" "s3_bucket" {
   count  = var.managed ? 0 : 1
   bucket = rhcs_rosa_oidc_config_input.oidc_input[count.index].bucket_name
@@ -27,6 +28,8 @@ resource "aws_s3_bucket" "s3_bucket" {
   })
 }
 
+#trivy:ignore:aws-0087 # Unmanaged OIDC: public bucket policy required for issuer discovery (GetObject).
+#trivy:ignore:aws-0093 # Unmanaged OIDC: allow public policy attachment for discovery objects.
 resource "aws_s3_bucket_public_access_block" "public_access_block" {
   count  = var.managed ? 0 : 1
   bucket = aws_s3_bucket.s3_bucket[count.index].id

--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,7 @@
       "description": "Manage bumping the version of the common bash library",
       "fileMatch": ["scripts/terraform-docs.sh$"],
       "matchStrings": [
-        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?TAG=(?<currentValue>.*)\\s"
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?VERSION=(?<currentValue>.*)\\s"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,16 @@
     "schedule": ["at any time"]
   },
   "labels": ["ok-to-test"],
+  "regexManagers": [
+    {
+      "description": "Manage bumping the version of the common bash library",
+      "fileMatch": ["scripts/terraform-docs.sh$"],
+      "matchStrings": [
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?TAG=(?<currentValue>.*)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
+  ],
   "packageRules": [
     {
       "description": "Terraform providers and version in the root versions.tf",

--- a/scripts/terraform-docs.sh
+++ b/scripts/terraform-docs.sh
@@ -1,6 +1,22 @@
 #!/bin/bash
 
 set -e
+# renovate: datasource=github-releases depName=terraform-docs/terraform-docs
+TERRAFORM_DOCS_VERSION=v0.22.0
+BINARY=terraform-docs
+set +e
+INSTALLED_TERRADOCS_VERSION="$(terraform-docs --version | head -1 | cut -d' ' -f3)"
+set -e
+if [[ "$TERRAFORM_DOCS_VERSION" != "$INSTALLED_TERRADOCS_VERSION" ]]; then
+  curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/${TERRAFORM_DOCS_VERSION}/terraform-docs-${TERRAFORM_DOCS_VERSION}-$(uname)-amd64.tar.gz
+  tar -xzf terraform-docs.tar.gz terraform-docs
+  chmod +x terraform-docs
+  echo "sudo required for moving terraform-docs to /usr/local/bin"
+  sudo mv terraform-docs /usr/local/bin/terraform-docs
+  rm terraform-docs.tar.gz
+else
+  echo "${BINARY} ${TERRAFORM_DOCS_VERSION} already installed - skipping install"
+fi
 terraform-docs version
 for d in . modules/* examples/*; do
   echo $d

--- a/scripts/terraform-docs.sh
+++ b/scripts/terraform-docs.sh
@@ -5,15 +5,34 @@ set -e
 TERRAFORM_DOCS_VERSION=v0.22.0
 BINARY=terraform-docs
 set +e
-INSTALLED_TERRADOCS_VERSION="$(terraform-docs --version | head -1 | cut -d' ' -f3)"
+INSTALLED_TERRADOCS_VERSION="$(terraform-docs --version 2> /dev/null | head -1 | cut -d' ' -f3)"
+ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH="amd64"; elif [[ ${ARCH} == "aarch64" ]]; then export ARCH="arm64"; fi 
+PLATFORM=$( uname | tr '[:upper:]' '[:lower:]')
 set -e
 if [[ "$TERRAFORM_DOCS_VERSION" != "$INSTALLED_TERRADOCS_VERSION" ]]; then
-  curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/${TERRAFORM_DOCS_VERSION}/terraform-docs-${TERRAFORM_DOCS_VERSION}-$(uname)-amd64.tar.gz
-  tar -xzf terraform-docs.tar.gz terraform-docs
+  echo "Installing terraform-docs ${TERRAFORM_DOCS_VERSION}"
+  curl -sSLo ./terraform-docs-${TERRAFORM_DOCS_VERSION}-${PLATFORM}-${ARCH}.tar.gz https://terraform-docs.io/dl/${TERRAFORM_DOCS_VERSION}/terraform-docs-${TERRAFORM_DOCS_VERSION}-${PLATFORM}-${ARCH}.tar.gz
+  curl -sSLo ./terraform-docs.tar.gz.sha256sum https://terraform-docs.io/dl/${TERRAFORM_DOCS_VERSION}/terraform-docs-${TERRAFORM_DOCS_VERSION}.sha256sum
+  if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1; then
+    echo "sha256sum and shasum notfound" >&2
+    exit 1
+  fi
+  if command -v sha256sum >/dev/null 2>&1; then
+    SHA_VERIFY=(sha256sum --ignore-missing -c "terraform-docs.tar.gz.sha256sum")
+  else
+    SHA_VERIFY=(shasum --ignore-missing -a 256 -c "terraform-docs.tar.gz.sha256sum")
+  fi
+  if "${SHA_VERIFY[@]}"; then
+    echo "File verification successful"
+  else
+    echo "File verification failed" >&2
+    exit 1
+  fi
+  tar -xzf terraform-docs-${TERRAFORM_DOCS_VERSION}-${PLATFORM}-${ARCH}.tar.gz terraform-docs
   chmod +x terraform-docs
   echo "sudo required for moving terraform-docs to /usr/local/bin"
   sudo mv terraform-docs /usr/local/bin/terraform-docs
-  rm terraform-docs.tar.gz
+  rm terraform-docs-${TERRAFORM_DOCS_VERSION}-${PLATFORM}-${ARCH}.tar.gz ./terraform-docs.tar.gz.sha256sum
 else
   echo "${BINARY} ${TERRAFORM_DOCS_VERSION} already installed - skipping install"
 fi
@@ -23,3 +42,4 @@ for d in . modules/* examples/*; do
   rm -rf $d/.terraform $d/.terraform.lock.hcl
   terraform-docs -c .terraform-docs.yml $d
 done
+

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,34 @@
+---
+# Trivy — static IaC misconfiguration for this ROSA HCP Terraform module repo.
+# Used with `trivy config --config trivy.yaml .` and by CodeRabbit when Trivy
+# is enabled (see .coderabbit.yaml). Scans root, modules/**, examples/**, and
+# Dockerfile. Prefer inline `#trivy:ignore:<ID>` on the flagged resource (see
+# AGENTS.md); repo-wide `.trivyignore` only as a last resort.
+#
+# https://trivy.dev/latest/docs/references/configuration/config-file/
+# https://trivy.dev/latest/docs/configuration/filtering/
+# Parser WARNs about missing var values are normal for modules without tfvars.
+
+# Match CodeRabbit chill-style signal; suppress MEDIUM/LOW/UNKNOWN noise.
+severity:
+  - CRITICAL
+  - HIGH
+
+scan:
+  skip-dirs:
+    - "**/.terraform"
+  # No Terraform plan JSON/snapshot inputs; no tfvars (consumer-supplied).
+  skip-files:
+    - "**/*.tfvars"
+    - "**/*.tfvars.json"
+    - "**/*.auto.tfvars"
+    - "**/*.auto.tfvars.json"
+  # IaC misconfiguration only — not vuln DB scans on lockfiles / container SBOM.
+  scanners:
+    - misconfig
+
+misconfiguration:
+  # Static Terraform HCL + root Dockerfile only (no plan-derived scans).
+  scanners:
+    - terraform
+    - dockerfile


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when an item does not apply.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For details, see: ./CONTRIBUTING.md
-->

## PR Summary

This PR is one of a series to create a standard for terraform repos:
- Add trivy config (ran by coderabbit so thats why we are not setting a workflow here)
- Change terraform-docs to make sure that we are using same version as in Dockerfile
- Add coderabbit config
- Add trivy config and update agents regarding that
- Enable gitleaks in coderabbit + gitleaks config for ignoring tftest files
- Enable inheritance in coderabbit

## Detailed Description of the Issue


## Related Issues and PRs
<!-- Link all tracking items and related code changes -->
- Jira: [OCM-23911](https://issues.redhat.com/browse/OCM-00000) <!-- replace if placeholder -->
- Fixes: `#`
- Related PR(s):
- Related design/docs: [terraform-docs installation](https://terraform-docs.io/user-guide/installation/)

## Type of Change
<!-- Check the primary type this PR represents -->
- [ ] feat - adds a new module capability or new user-facing behavior.
- [ ] fix - resolves incorrect module behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting/naming changes with no logic impact.
- [ ] refactor - module code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [x] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior


## Behavior After This Change


## How to Test (Step-by-Step)
<!-- Provide reproducible validation instructions for module maintainers/reviewers -->

### Preconditions
<!-- Required setup: Terraform version, credentials, env vars (e.g. RHCS_TOKEN/AWS creds), provider versions, test data, etc. -->
- Network access to **`terraform-docs.io`** for the first download; **`bash`**, **`curl`**, **`tar`**.

### Test Steps

### Expected Results
- **`terraform-docs version`** output matches the version parsed from **`Dockerfile`**.
- README inject blocks update consistently with the pinned CLI (compare to prior behavior only if you have a baseline).

## Proof of the Fix
<!-- Attach evidence that demonstrates the changed behavior -->
- Screenshots:
- Videos:
- Logs/CLI output:
- Other artifacts:

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
<!-- Required only when breaking changes are introduced.
Examples: variable rename/removal, output rename/removal, default value change, resource behavior changes, provider/version requirement changes. -->
N/A

## Developer Verification Checklist
- [ ] **AWS-only changes:** If this PR is mainly **AWS-only** (no `rhcs` resources/variables), I linked **official Red Hat or cited ROSA HCP documentation** that supports reference alignment, or I explained why the change still belongs in-repo per **Module scope (AWS-only vs core HCP)** in [`.cursor/rules/rosa-hcp-terraform.mdc`](.cursor/rules/rosa-hcp-terraform.mdc).
- [X] I checked if this affects terraform-rhcs-rosa-classic and submitted (or already submitted) a companion PR when needed. (to be done once this is approved)
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [ ] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [x] `make verify` passes.
- [x] `make verify-gen` passes.
- [x] Documentation was added/updated where appropriate (see `make terraform-docs`).
- [x] Any risk, limitation, or follow-up work is documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled repository security/lint tooling with selective rules and allowlists (Trivy, Checkov, TFLint, Shellcheck, Hadolint, Gitleaks, YAMLLint) and added repo-level scan/ignore configurations.
  * Added path-specific scanner suppressions and targeted inline suppressions in infrastructure modules.
  * Pinned the documentation generator binary and excluded its cache; added automated dependency extraction rules.

* **Documentation**
  * Added guidance for handling Trivy IaC misconfiguration findings and inline suppressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->