### PR TITLE
ROSAENG-6808 | feat: add OCM role submodule with required ROSA CLI tags

### DIFF
--- a/examples/ocm-role/README.md
+++ b/examples/ocm-role/README.md
@@ -1,0 +1,42 @@
+# ocm-role example
+
+Creates and links an OCM IAM role with the required ROSA CLI-parity tags using the `ocm-role` module.
+
+<!-- BEGIN_AUTOMATED_TF_DOCS_BLOCK -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
+| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | >= 1.7.7 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_ocm_role"></a> [ocm\_role](#module\_ocm\_role) | ../../modules/ocm-role | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_ocm_role_prefix"></a> [ocm\_role\_prefix](#input\_ocm\_role\_prefix) | User-defined prefix for the OCM IAM role name. | `string` | `"ManagedOpenShift"` | no |
+| <a name="input_profile"></a> [profile](#input\_profile) | Profile of the OCM role to create. Allowed values are `standard`, `admin`, and `no-console`. | `string` | `"standard"` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_role_arn"></a> [role\_arn](#output\_role\_arn) | The ARN of the created OCM IAM role. |
+| <a name="output_role_link_id"></a> [role\_link\_id](#output\_role\_link\_id) | The identifier of the OCM-side role link. |
+| <a name="output_role_name"></a> [role\_name](#output\_role\_name) | The name of the created OCM IAM role. |
+<!-- END_AUTOMATED_TF_DOCS_BLOCK -->

--- a/examples/ocm-role/main.tf
+++ b/examples/ocm-role/main.tf
@@ -1,0 +1,12 @@
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+
+############################
+# OCM Role
+############################
+module "ocm_role" {
+  source = "../../modules/ocm-role"
+
+  ocm_role_prefix = var.ocm_role_prefix
+  profile         = var.profile
+}

--- a/examples/ocm-role/outputs.tf
+++ b/examples/ocm-role/outputs.tf
@@ -1,0 +1,17 @@
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+
+output "role_arn" {
+  value       = module.ocm_role.role_arn
+  description = "The ARN of the created OCM IAM role."
+}
+
+output "role_name" {
+  value       = module.ocm_role.role_name
+  description = "The name of the created OCM IAM role."
+}
+
+output "role_link_id" {
+  value       = module.ocm_role.role_link_id
+  description = "The identifier of the OCM-side role link."
+}

--- a/examples/ocm-role/variables.tf
+++ b/examples/ocm-role/variables.tf
@@ -1,0 +1,14 @@
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+
+variable "ocm_role_prefix" {
+  type        = string
+  description = "User-defined prefix for the OCM IAM role name."
+  default     = "ManagedOpenShift"
+}
+
+variable "profile" {
+  type        = string
+  description = "Profile of the OCM role to create. Allowed values are `standard`, `admin`, and `no-console`."
+  default     = "standard"
+}

--- a/examples/ocm-role/versions.tf
+++ b/examples/ocm-role/versions.tf
@@ -1,0 +1,17 @@
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+    rhcs = {
+      source  = "terraform-redhat/rhcs"
+      version = ">= 1.7.7"
+    }
+  }
+}

--- a/modules/ocm-role/README.md
+++ b/modules/ocm-role/README.md
@@ -1,0 +1,76 @@
+# ocm-role
+
+## Introduction
+
+This Terraform sub-module creates the AWS IAM OCM role with the tags required by the ROSA CLI and OCM. The role is used to grant OpenShift Cluster Manager permissions in the customer's AWS account.
+
+The module creates the IAM role, attaches the appropriate permission policies for the selected profile, applies the required tags, and links the role to the current OCM organization via `rhcs_rosa_ocm_role_link`.
+
+For more information, see [Understanding OCM role and User role for ROSA](https://access.redhat.com/articles/6961686).
+
+## Example Usage
+
+```
+module "ocm_role" {
+  source  = "terraform-redhat/rosa-hcp/rhcs//modules/ocm-role"
+  version = "1.7.7"
+
+  ocm_role_prefix = "ManagedOpenShift"
+  profile         = "standard"
+}
+```
+
+<!-- BEGIN_AUTOMATED_TF_DOCS_BLOCK -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
+| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | >= 1.7.7 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
+| <a name="provider_rhcs"></a> [rhcs](#provider\_rhcs) | >= 1.7.7 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [aws_iam_policy.ocm_admin_permission_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.ocm_no_console_permission_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.standard_permission_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.ocm_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.ocm_admin_permission_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.ocm_no_console_permission_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.standard_permission_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [rhcs_rosa_ocm_role_link.this](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/resources/rosa_ocm_role_link) | resource |
+| [rhcs_hcp_policies.all_policies](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/data-sources/hcp_policies) | data source |
+| [rhcs_info.current](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/data-sources/info) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_create_link"></a> [create\_link](#input\_create\_link) | (Optional) Whether to link the created role to the OCM organization via rhcs\_rosa\_ocm\_role\_link. Set to false when importing an already-linked role. | `bool` | `true` | no |
+| <a name="input_ocm_role_prefix"></a> [ocm\_role\_prefix](#input\_ocm\_role\_prefix) | User-defined prefix for the OCM IAM role name. The final role name is `<prefix>-OCM-Role-<organization_external_id>`. | `string` | n/a | yes |
+| <a name="input_path"></a> [path](#input\_path) | (Optional) The IAM path for the OCM role and its policies. Must begin and end with '/'. | `string` | `"/"` | no |
+| <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | (Optional) The ARN of the policy used to set the permissions boundary for the OCM IAM role. | `string` | `""` | no |
+| <a name="input_profile"></a> [profile](#input\_profile) | Profile of the OCM role to create. Allowed values are `standard`, `admin`, and `no-console`. | `string` | `"standard"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) Additional AWS resource tags to merge into the OCM role and its policies. | `map(string)` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_role_arn"></a> [role\_arn](#output\_role\_arn) | The ARN of the created OCM IAM role. |
+| <a name="output_role_link_id"></a> [role\_link\_id](#output\_role\_link\_id) | The identifier of the OCM-side role link created for the IAM role, or null when create\_link is false. |
+| <a name="output_role_name"></a> [role\_name](#output\_role\_name) | The name of the created OCM IAM role. |
+<!-- END_AUTOMATED_TF_DOCS_BLOCK -->

--- a/modules/ocm-role/main.tf
+++ b/modules/ocm-role/main.tf
@@ -1,0 +1,113 @@
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+
+locals {
+  path = coalesce(var.path, "/")
+
+  role_type               = "OCM"
+  role_suffix             = "-${local.role_type}-Role-${data.rhcs_info.current.organization_external_id}"
+  max_prefix_length       = 64 - length(local.role_suffix)
+  truncated_role_prefix   = local.max_prefix_length > 0 ? substr(var.ocm_role_prefix, 0, local.max_prefix_length) : ""
+  role_name               = "${local.truncated_role_prefix}${local.role_suffix}"
+  max_policy_name_length  = 128
+  standard_policy_enabled = contains(["standard", "admin"], var.profile)
+  admin_policy_enabled    = var.profile == "admin"
+  no_console_enabled      = var.profile == "no-console"
+
+  ocm_environment = (
+    strcontains(data.rhcs_info.current.ocm_api, "api.stage.") ? "staging" :
+    (
+      strcontains(data.rhcs_info.current.ocm_api, "integration") || strcontains(data.rhcs_info.current.ocm_api, ".int.") ? "integration" : "production"
+    )
+  )
+
+  base_tags = merge(var.tags, {
+    red-hat-managed  = true
+    rosa_role_prefix = var.ocm_role_prefix
+    rosa_role_type   = local.role_type
+    rosa_environment = local.ocm_environment
+  })
+
+  role_tags = local.admin_policy_enabled ? merge(local.base_tags, {
+    rosa_admin_role = true
+    }) : (
+    local.no_console_enabled ? merge(local.base_tags, {
+      rosa_no_console_role = true
+    }) : local.base_tags
+  )
+}
+
+data "rhcs_hcp_policies" "all_policies" {}
+
+data "rhcs_info" "current" {}
+
+resource "aws_iam_role" "ocm_role" {
+  name                  = local.role_name
+  permissions_boundary  = var.permissions_boundary
+  path                  = local.path
+  assume_role_policy    = data.rhcs_hcp_policies.all_policies.ocm_role_policies.sts_ocm_trust_policy
+  force_detach_policies = true
+
+  tags = local.role_tags
+}
+
+resource "aws_iam_policy" "standard_permission_policy" {
+  count = local.standard_policy_enabled ? 1 : 0
+
+  name   = substr("${local.role_name}-Policy", 0, local.max_policy_name_length)
+  path   = local.path
+  policy = data.rhcs_hcp_policies.all_policies.ocm_role_policies.sts_ocm_permission_policy
+
+  tags = local.base_tags
+}
+
+resource "aws_iam_role_policy_attachment" "standard_permission_policy_attachment" {
+  count = local.standard_policy_enabled ? 1 : 0
+
+  role       = aws_iam_role.ocm_role.name
+  policy_arn = aws_iam_policy.standard_permission_policy[0].arn
+}
+
+resource "aws_iam_policy" "ocm_admin_permission_policy" {
+  count = local.admin_policy_enabled ? 1 : 0
+
+  name   = substr("${local.role_name}-Admin-Policy", 0, local.max_policy_name_length)
+  path   = local.path
+  policy = data.rhcs_hcp_policies.all_policies.ocm_role_policies.sts_ocm_admin_permission_policy
+
+  tags = merge(local.base_tags, {
+    rosa_admin_role = true
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ocm_admin_permission_policy_attachment" {
+  count = local.admin_policy_enabled ? 1 : 0
+
+  role       = aws_iam_role.ocm_role.name
+  policy_arn = aws_iam_policy.ocm_admin_permission_policy[0].arn
+}
+
+resource "aws_iam_policy" "ocm_no_console_permission_policy" {
+  count = local.no_console_enabled ? 1 : 0
+
+  name   = substr("${local.role_name}-NoConsole-Policy", 0, local.max_policy_name_length)
+  path   = local.path
+  policy = data.rhcs_hcp_policies.all_policies.ocm_role_policies.sts_ocm_no_console_permission_policy
+
+  tags = merge(local.base_tags, {
+    rosa_no_console_role = true
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ocm_no_console_permission_policy_attachment" {
+  count = local.no_console_enabled ? 1 : 0
+
+  role       = aws_iam_role.ocm_role.name
+  policy_arn = aws_iam_policy.ocm_no_console_permission_policy[0].arn
+}
+
+resource "rhcs_rosa_ocm_role_link" "this" {
+  count = var.create_link ? 1 : 0
+
+  role_arn = aws_iam_role.ocm_role.arn
+}

--- a/modules/ocm-role/outputs.tf
+++ b/modules/ocm-role/outputs.tf
@@ -1,0 +1,17 @@
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+
+output "role_arn" {
+  value       = aws_iam_role.ocm_role.arn
+  description = "The ARN of the created OCM IAM role."
+}
+
+output "role_name" {
+  value       = aws_iam_role.ocm_role.name
+  description = "The name of the created OCM IAM role."
+}
+
+output "role_link_id" {
+  value       = try(rhcs_rosa_ocm_role_link.this[0].id, null)
+  description = "The identifier of the OCM-side role link created for the IAM role, or null when create_link is false."
+}

--- a/modules/ocm-role/tests/ocm_role.tftest.hcl
+++ b/modules/ocm-role/tests/ocm_role.tftest.hcl
@@ -1,0 +1,348 @@
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+
+mock_provider "aws" {
+  alias = "default"
+}
+
+mock_provider "rhcs" {
+  alias           = "prod"
+  override_during = plan
+
+  mock_data "rhcs_info" {
+    defaults = {
+      organization_external_id = "orgext123"
+      ocm_api                  = "https://api.openshift.com"
+      ocm_aws_account_id       = "000000000000"
+    }
+  }
+
+  mock_data "rhcs_hcp_policies" {
+    defaults = {
+      ocm_role_policies = {
+        sts_ocm_trust_policy                 = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"sts:AssumeRole\",\"Principal\":{\"AWS\":\"arn:aws:iam::000000000000:root\"}}]}"
+        sts_ocm_permission_policy            = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"iam:GetRole\"],\"Resource\":\"*\"}]}"
+        sts_ocm_admin_permission_policy      = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"iam:*\"],\"Resource\":\"*\"}]}"
+        sts_ocm_no_console_permission_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"iam:GetRole\",\"Resource\":\"*\"}]}"
+      }
+    }
+  }
+
+  mock_resource "rhcs_rosa_ocm_role_link" {
+    defaults = {
+      id = "ocm-link-id"
+    }
+  }
+}
+
+mock_provider "rhcs" {
+  alias           = "stage"
+  override_during = plan
+
+  mock_data "rhcs_info" {
+    defaults = {
+      organization_external_id = "orgext123"
+      ocm_api                  = "https://api.stage.openshift.com"
+      ocm_aws_account_id       = "000000000000"
+    }
+  }
+
+  mock_data "rhcs_hcp_policies" {
+    defaults = {
+      ocm_role_policies = {
+        sts_ocm_trust_policy                 = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"sts:AssumeRole\",\"Principal\":{\"AWS\":\"arn:aws:iam::000000000000:root\"}}]}"
+        sts_ocm_permission_policy            = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"iam:GetRole\"],\"Resource\":\"*\"}]}"
+        sts_ocm_admin_permission_policy      = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"iam:*\"],\"Resource\":\"*\"}]}"
+        sts_ocm_no_console_permission_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"iam:GetRole\",\"Resource\":\"*\"}]}"
+      }
+    }
+  }
+
+  mock_resource "rhcs_rosa_ocm_role_link" {
+    defaults = {
+      id = "ocm-link-id"
+    }
+  }
+}
+
+mock_provider "rhcs" {
+  alias           = "int"
+  override_during = plan
+
+  mock_data "rhcs_info" {
+    defaults = {
+      organization_external_id = "orgext123"
+      ocm_api                  = "https://api.integration.openshift.com"
+      ocm_aws_account_id       = "000000000000"
+    }
+  }
+
+  mock_data "rhcs_hcp_policies" {
+    defaults = {
+      ocm_role_policies = {
+        sts_ocm_trust_policy                 = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"sts:AssumeRole\",\"Principal\":{\"AWS\":\"arn:aws:iam::000000000000:root\"}}]}"
+        sts_ocm_permission_policy            = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"iam:GetRole\"],\"Resource\":\"*\"}]}"
+        sts_ocm_admin_permission_policy      = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"iam:*\"],\"Resource\":\"*\"}]}"
+        sts_ocm_no_console_permission_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"iam:GetRole\",\"Resource\":\"*\"}]}"
+      }
+    }
+  }
+
+  mock_resource "rhcs_rosa_ocm_role_link" {
+    defaults = {
+      id = "ocm-link-id"
+    }
+  }
+}
+
+# Standard OCM role (default profile) -- plans successfully with correct tags, naming, and link.
+run "standard_ocm_role_plan" {
+  command = plan
+
+  providers = {
+    rhcs = rhcs.prod
+    aws  = aws.default
+  }
+
+  variables {
+    ocm_role_prefix = "ManagedOpenShift"
+  }
+
+  assert {
+    condition     = aws_iam_role.ocm_role.name == "ManagedOpenShift-OCM-Role-orgext123"
+    error_message = "Expected OCM role name to follow the ROSA CLI naming pattern."
+  }
+
+  assert {
+    condition     = aws_iam_role.ocm_role.tags["red-hat-managed"] == "true"
+    error_message = "Expected red-hat-managed tag to be true."
+  }
+
+  assert {
+    condition     = aws_iam_role.ocm_role.tags["rosa_role_prefix"] == "ManagedOpenShift"
+    error_message = "Expected rosa_role_prefix tag to match the prefix variable."
+  }
+
+  assert {
+    condition     = aws_iam_role.ocm_role.tags["rosa_role_type"] == "OCM"
+    error_message = "Expected rosa_role_type tag to be OCM."
+  }
+
+  assert {
+    condition     = aws_iam_role.ocm_role.tags["rosa_environment"] == "production"
+    error_message = "Expected rosa_environment tag to default to production."
+  }
+
+  assert {
+    condition     = !contains(keys(aws_iam_role.ocm_role.tags), "rosa_admin_role")
+    error_message = "Standard role must not have rosa_admin_role tag."
+  }
+
+  assert {
+    condition     = !contains(keys(aws_iam_role.ocm_role.tags), "rosa_no_console_role")
+    error_message = "Standard role must not have rosa_no_console_role tag."
+  }
+
+  assert {
+    condition     = length(aws_iam_policy.standard_permission_policy) == 1
+    error_message = "Standard role must create the standard permission policy."
+  }
+
+  assert {
+    condition     = length(aws_iam_policy.ocm_admin_permission_policy) == 0
+    error_message = "Standard role must not create the admin permission policy."
+  }
+
+  assert {
+    condition     = length(aws_iam_policy.ocm_no_console_permission_policy) == 0
+    error_message = "Standard role must not create the no-console permission policy."
+  }
+
+  assert {
+    condition     = rhcs_rosa_ocm_role_link.this[0].id == "ocm-link-id"
+    error_message = "Expected the module to create the OCM-side link resource."
+  }
+}
+
+# Admin OCM role -- plans with standard + admin policies.
+run "admin_ocm_role_plan" {
+  command = plan
+
+  providers = {
+    rhcs = rhcs.prod
+    aws  = aws.default
+  }
+
+  variables {
+    ocm_role_prefix = "ManagedOpenShift"
+    profile         = "admin"
+  }
+
+  assert {
+    condition     = aws_iam_role.ocm_role.tags["rosa_admin_role"] == "true"
+    error_message = "Admin role must have rosa_admin_role=true tag."
+  }
+
+  assert {
+    condition     = !contains(keys(aws_iam_role.ocm_role.tags), "rosa_no_console_role")
+    error_message = "Admin role must not have rosa_no_console_role tag."
+  }
+
+  assert {
+    condition     = length(aws_iam_policy.standard_permission_policy) == 1
+    error_message = "Admin role must keep the standard permission policy."
+  }
+
+  assert {
+    condition     = length(aws_iam_policy.ocm_admin_permission_policy) == 1
+    error_message = "Admin role must create exactly one admin permission policy."
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy_attachment.standard_permission_policy_attachment) == 1
+    error_message = "Admin role must attach the standard permission policy."
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy_attachment.ocm_admin_permission_policy_attachment) == 1
+    error_message = "Admin role must attach the admin permission policy."
+  }
+}
+
+# No-console OCM role -- plans with no-console tag and policy only.
+run "no_console_ocm_role_plan" {
+  command = plan
+
+  providers = {
+    rhcs = rhcs.prod
+    aws  = aws.default
+  }
+
+  variables {
+    ocm_role_prefix = "ManagedOpenShift"
+    profile         = "no-console"
+  }
+
+  assert {
+    condition     = aws_iam_role.ocm_role.tags["rosa_no_console_role"] == "true"
+    error_message = "No-console role must have rosa_no_console_role=true tag."
+  }
+
+  assert {
+    condition     = !contains(keys(aws_iam_role.ocm_role.tags), "rosa_admin_role")
+    error_message = "No-console role must not have rosa_admin_role tag."
+  }
+
+  assert {
+    condition     = length(aws_iam_policy.standard_permission_policy) == 0
+    error_message = "No-console role must not create the standard permission policy."
+  }
+
+  assert {
+    condition     = length(aws_iam_policy.ocm_admin_permission_policy) == 0
+    error_message = "No-console role must not create the admin permission policy."
+  }
+
+  assert {
+    condition     = length(aws_iam_policy.ocm_no_console_permission_policy) == 1
+    error_message = "No-console role must create the no-console permission policy."
+  }
+}
+
+# Derived environment tag from OCM API.
+run "staging_environment_plan" {
+  command = plan
+
+  providers = {
+    rhcs = rhcs.stage
+    aws  = aws.default
+  }
+
+  variables {
+    ocm_role_prefix = "MyPrefix"
+  }
+
+  assert {
+    condition     = aws_iam_role.ocm_role.tags["rosa_environment"] == "staging"
+    error_message = "Expected rosa_environment tag to be derived as staging."
+  }
+
+  assert {
+    condition     = aws_iam_role.ocm_role.tags["rosa_role_prefix"] == "MyPrefix"
+    error_message = "Expected rosa_role_prefix tag to match the provided prefix."
+  }
+}
+
+# Derived environment tag from OCM API (integration).
+run "integration_environment_plan" {
+  command = plan
+
+  providers = {
+    rhcs = rhcs.int
+    aws  = aws.default
+  }
+
+  variables {
+    ocm_role_prefix = "MyPrefix"
+  }
+
+  assert {
+    condition     = aws_iam_role.ocm_role.tags["rosa_environment"] == "integration"
+    error_message = "Expected rosa_environment tag to be derived as integration."
+  }
+}
+
+# Invalid profile value fails validation.
+run "invalid_profile_fails" {
+  command = plan
+
+  providers = {
+    rhcs = rhcs.prod
+    aws  = aws.default
+  }
+
+  variables {
+    ocm_role_prefix = "ManagedOpenShift"
+    profile         = "invalid"
+  }
+
+  expect_failures = [
+    var.profile,
+  ]
+}
+
+# Prefix exceeding 32 characters fails validation.
+run "prefix_too_long_fails" {
+  command = plan
+
+  providers = {
+    rhcs = rhcs.prod
+    aws  = aws.default
+  }
+
+  variables {
+    ocm_role_prefix = "abcdefghijklmnopqrstuvwxyz1234567"
+  }
+
+  expect_failures = [
+    var.ocm_role_prefix,
+  ]
+}
+
+# Prefix with invalid characters fails validation.
+run "prefix_invalid_chars_fails" {
+  command = plan
+
+  providers = {
+    rhcs = rhcs.prod
+    aws  = aws.default
+  }
+
+  variables {
+    ocm_role_prefix = "invalid prefix!"
+  }
+
+  expect_failures = [
+    var.ocm_role_prefix,
+  ]
+}

--- a/modules/ocm-role/variables.tf
+++ b/modules/ocm-role/variables.tf
@@ -1,0 +1,57 @@
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+
+variable "ocm_role_prefix" {
+  type        = string
+  description = "User-defined prefix for the OCM IAM role name. The final role name is `<prefix>-OCM-Role-<organization_external_id>`."
+
+  validation {
+    condition     = can(regex("^[\\w+=,.@-]+$", var.ocm_role_prefix))
+    error_message = "ocm_role_prefix must match [\\w+=,.@-]+ (alphanumeric, plus, equals, comma, period, at, hyphen)."
+  }
+
+  validation {
+    condition     = length(var.ocm_role_prefix) <= 32
+    error_message = "ocm_role_prefix must be 32 characters or fewer."
+  }
+}
+
+variable "profile" {
+  type        = string
+  description = "Profile of the OCM role to create. Allowed values are `standard`, `admin`, and `no-console`."
+  default     = "standard"
+
+  validation {
+    condition     = contains(["standard", "admin", "no-console"], var.profile)
+    error_message = "profile must be one of: standard, admin, no-console."
+  }
+}
+
+variable "path" {
+  type        = string
+  description = "(Optional) The IAM path for the OCM role and its policies. Must begin and end with '/'."
+  default     = "/"
+
+  validation {
+    condition     = var.path == "/" || can(regex("^/.+/$", var.path))
+    error_message = "path must be '/' or a value that begins and ends with '/'."
+  }
+}
+
+variable "permissions_boundary" {
+  type        = string
+  description = "(Optional) The ARN of the policy used to set the permissions boundary for the OCM IAM role."
+  default     = ""
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "(Optional) Additional AWS resource tags to merge into the OCM role and its policies."
+  default     = null
+}
+
+variable "create_link" {
+  type        = bool
+  description = "(Optional) Whether to link the created role to the OCM organization via rhcs_rosa_ocm_role_link. Set to false when importing an already-linked role."
+  default     = true
+}

--- a/modules/ocm-role/versions.tf
+++ b/modules/ocm-role/versions.tf
@@ -1,0 +1,17 @@
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+    rhcs = {
+      source  = "terraform-redhat/rhcs"
+      version = ">= 1.7.7"
+    }
+  }
+}


### PR DESCRIPTION
## PR Summary
Add `modules/ocm-role/` submodule that creates the AWS IAM OCM role with the tags required by the ROSA CLI, and an example showing composition with `rhcs_rosa_ocm_role_link`.

## Detailed Description of the Issue
The ROSA CLI tags OCM IAM roles with `red-hat-managed`, `rosa_role_prefix`, `rosa_role_type`, `rosa_environment`, and conditionally `rosa_admin_role`. The terraform-rhcs-rosa-hcp module had no OCM role creation path, so customers using Terraform-only workflows had to tag the role manually or risk the role not being recognized by ROSA tooling.

This PR adds a standalone `modules/ocm-role/` submodule that creates the OCM IAM role with the correct tags, builds the trust policy trusting `RH-Managed-OpenShift-Installer` in the OCM AWS account (with `sts:ExternalId` for the org ID), and attaches the appropriate permission policy (standard or admin) from `data.rhcs_hcp_policies.ocm_role_policies`.

The submodule is not wired into root `main.tf` because the OCM role is org-level (one per AWS account per organization), not cluster-level. Instead, the example at `examples/ocm-role/` shows how to compose the submodule with `rhcs_rosa_ocm_role_link` for the full flow.

## Related Issues and PRs
- Jira: [ROSAENG-6808](https://redhat.atlassian.net/browse/ROSAENG-6808)
- Parent: [ROSAENG-6789](https://redhat.atlassian.net/browse/ROSAENG-6789)
- Related PR(s): [terraform-provider-rhcs#1156](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1156) (merged — adds `rhcs_rosa_ocm_role_link` and `ocm_role_policies`)
- Related design/docs: [Understanding OCM role and User role for ROSA](https://access.redhat.com/articles/6961686)

## Type of Change
- [x] feat - adds a new module capability or new user-facing behavior.
- [ ] fix - resolves incorrect module behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting/naming changes with no logic impact.
- [ ] refactor - module code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
The HCP module had no OCM role creation path. Customers had to create and tag the OCM IAM role manually or via the ROSA CLI.

## Behavior After This Change
Customers can call `modules/ocm-role/` to create a compliant OCM IAM role with all required ROSA CLI-parity tags, then compose with `rhcs_rosa_ocm_role_link` to complete the OCM-side link.

Tags applied to the role match the ROSA CLI contract:
- `red-hat-managed` = `true`
- `rosa_role_prefix` = user-specified prefix
- `rosa_role_type` = `ocm`
- `rosa_environment` = OCM environment
- `rosa_admin_role` = `true` (only when `admin = true`)

## How to Test (Step-by-Step)

### Preconditions
Terraform >= 1.0 installed. No live credentials needed for the mock-based tests.

### Test Steps
1. `cd modules/ocm-role && terraform init -backend=false && terraform test`
2. `terraform fmt -check -recursive modules/ocm-role/ examples/ocm-role/`
3. `cd examples/ocm-role && terraform init -backend=false && terraform validate`
4. `make terraform-docs && make verify-gen`

### Expected Results
All 6 tests pass (standard role, admin role, custom environment, invalid environment, prefix too long, prefix invalid chars). Format check and validate pass. Docs are up to date.

## Proof of the Fix
- Logs/CLI output: `terraform test` — 6 passed, 0 failed
- Other artifacts: Generated `README.md` for both submodule and example

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] **AWS-only changes:** This submodule uses `rhcs` data sources (`rhcs_hcp_policies`, `rhcs_info`) alongside AWS resources. Official docs linked: [Understanding OCM role and User role for ROSA](https://access.redhat.com/articles/6961686).
- [x] I checked if this affects terraform-rhcs-rosa-classic and submitted (or already submitted) a companion PR when needed. ([ROSAENG-6809](https://redhat.atlassian.net/browse/ROSAENG-6809) tracks the classic module separately.)
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make verify` passes.
- [x] `make verify-gen` passes.
- [x] Documentation was added/updated where appropriate (see `make terraform-docs`).
- [x] Any risk, limitation, or follow-up work is documented.

## Risks / Follow-ups
- The no-console profile tag (`rosa_no_console_role`) is deferred until the tag contract is confirmed in the ROSA CLI.
- This submodule requires `rhcs >= 1.7.6` (provider with `ocm_role_policies` support). Root `versions.tf` already declares this floor.
- The sibling classic module update is tracked separately in [ROSAENG-6809](https://redhat.atlassian.net/browse/ROSAENG-6809).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OCM IAM role module to create AWS roles with OCM integration, supporting standard, admin, and no-console profiles, conditional linking, and outputs for role ARN/name/link ID.

* **Documentation**
  * Added comprehensive module and example docs with usage examples and embedded automated Terraform docs (requirements, inputs, outputs).

* **Examples**
  * Added a runnable example showing module usage, variables, and example outputs.

* **Tests**
  * Added test suite validating profiles, environment-derived tags, and input validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->