### PR TITLE
ROSAENG-59425 | feat: add worker disk size support

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ We recommend you install the following CLI tools:
 | <a name="input_version_channel_group"></a> [version\_channel\_group](#input\_version\_channel\_group) | Desired channel group of the version [stable, candidate, fast, nightly]. Cannot be used together with 'channel'. Starting from RHCS Terraform provider version 1.7.7, this attribute no longer has a default value and is computed by the API. | `string` | `null` | no |
 | <a name="input_wait_for_create_complete"></a> [wait\_for\_create\_complete](#input\_wait\_for\_create\_complete) | Wait until the cluster is either in a ready state or in an error state. The waiter has a timeout of 20 minutes. (default: true) | `bool` | `true` | no |
 | <a name="input_wait_for_std_compute_nodes_complete"></a> [wait\_for\_std\_compute\_nodes\_complete](#input\_wait\_for\_std\_compute\_nodes\_complete) | Wait until the initial set of machine pools to be available. The waiter has a timeout of 60 minutes. (default: true) | `bool` | `true` | no |
+| <a name="input_worker_disk_size"></a> [worker\_disk\_size](#input\_worker\_disk\_size) | Default worker machine pool root disk size in GiB (e.g., 300, 400, 500). Leave null to use platform default. | `number` | `null` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -121,6 +121,7 @@ module "rosa_cluster_hcp" {
   replicas                                  = var.replicas
   compute_machine_type                      = var.compute_machine_type
   aws_availability_zones                    = var.aws_availability_zones
+  worker_disk_size                          = var.worker_disk_size
   aws_additional_compute_security_group_ids = var.aws_additional_compute_security_group_ids
 
   ########

--- a/modules/rosa-cluster-hcp/README.md
+++ b/modules/rosa-cluster-hcp/README.md
@@ -124,6 +124,7 @@ No modules.
 | <a name="input_version_channel_group"></a> [version\_channel\_group](#input\_version\_channel\_group) | Desired channel group of the version [stable, candidate, fast, nightly]. Cannot be used together with 'channel'. Starting from RHCS Terraform provider version 1.7.7, this attribute no longer has a default value and is computed by the API. | `string` | `null` | no |
 | <a name="input_wait_for_create_complete"></a> [wait\_for\_create\_complete](#input\_wait\_for\_create\_complete) | Wait until the cluster is either in a ready state or in an error state. The waiter has a timeout of 20 minutes. (default: true) | `bool` | `true` | no |
 | <a name="input_wait_for_std_compute_nodes_complete"></a> [wait\_for\_std\_compute\_nodes\_complete](#input\_wait\_for\_std\_compute\_nodes\_complete) | Wait until the cluster standard compute nodes are available. The waiter has a timeout of 60 minutes. (default: true) | `bool` | `true` | no |
+| <a name="input_worker_disk_size"></a> [worker\_disk\_size](#input\_worker\_disk\_size) | Worker node root disk size in GiB. | `number` | `null` | no |
 | <a name="input_worker_role_arn"></a> [worker\_role\_arn](#input\_worker\_role\_arn) | The Amazon Resource Name (ARN) associated with the AWS IAM role that will be used by the cluster's compute instances. | `string` | `null` | no |
 
 ## Outputs

--- a/modules/rosa-cluster-hcp/main.tf
+++ b/modules/rosa-cluster-hcp/main.tf
@@ -73,6 +73,7 @@ resource "rhcs_cluster_rosa_hcp" "rosa_hcp_cluster" {
   replicas                                  = var.replicas
   aws_subnet_ids                            = var.aws_subnet_ids
   compute_machine_type                      = var.compute_machine_type
+  worker_disk_size                          = var.worker_disk_size
   create_admin_user                         = local.create_admin_user
   admin_credentials                         = local.admin_credentials
   ec2_metadata_http_tokens                  = var.ec2_metadata_http_tokens

--- a/modules/rosa-cluster-hcp/tests/rosa_cluster_hcp.tftest.hcl
+++ b/modules/rosa-cluster-hcp/tests/rosa_cluster_hcp.tftest.hcl
@@ -225,3 +225,41 @@ run "invalid_channel_three_part_version" {
     var.channel,
   ]
 }
+
+# worker_disk_size passthrough: null value (platform default).
+run "worker_disk_size_null" {
+  command = plan
+
+  providers = {
+    aws  = aws.default
+    rhcs = rhcs.import_sim
+  }
+
+  variables {
+    worker_disk_size = null
+  }
+
+  assert {
+    condition     = rhcs_cluster_rosa_hcp.rosa_hcp_cluster.worker_disk_size == null
+    error_message = "worker_disk_size must be null when set to null (platform default)."
+  }
+}
+
+# worker_disk_size passthrough: explicit value (400 GiB).
+run "worker_disk_size_explicit" {
+  command = plan
+
+  providers = {
+    aws  = aws.default
+    rhcs = rhcs.import_sim
+  }
+
+  variables {
+    worker_disk_size = 400
+  }
+
+  assert {
+    condition     = rhcs_cluster_rosa_hcp.rosa_hcp_cluster.worker_disk_size == 400
+    error_message = "worker_disk_size must be 400 when explicitly set to 400."
+  }
+}

--- a/modules/rosa-cluster-hcp/variables.tf
+++ b/modules/rosa-cluster-hcp/variables.tf
@@ -313,6 +313,20 @@ variable "aws_availability_zones" {
   description = "The AWS availability zones where instances of the default worker machine pool are deployed. Leave empty for the installer to pick availability zones"
 }
 
+variable "worker_disk_size" {
+  type        = number
+  default     = null
+  description = "Worker node root disk size in GiB."
+
+  validation {
+    condition = var.worker_disk_size == null ? true : (
+      var.worker_disk_size > 0 &&
+      floor(var.worker_disk_size) == var.worker_disk_size
+    )
+    error_message = "worker_disk_size must be a positive whole number (GiB)."
+  }
+}
+
 variable "aws_additional_compute_security_group_ids" {
   type        = list(string)
   default     = null

--- a/variables.tf
+++ b/variables.tf
@@ -247,6 +247,12 @@ variable "aws_availability_zones" {
   description = "The AWS availability zones where instances of the default worker machine pool are deployed. Leave empty for the installer to pick availability zones"
 }
 
+variable "worker_disk_size" {
+  type        = number
+  default     = null
+  description = "Default worker machine pool root disk size in GiB (e.g., 300, 400, 500). Leave null to use platform default."
+}
+
 variable "aws_additional_compute_security_group_ids" {
   type        = list(string)
   default     = null


### PR DESCRIPTION
1) the problem: 
Customer has  requirements from IBM to have at least 300Gb of storage for IBM Maximo Application Suite.


They're deploying Openshift on AWS Platform using ROSA HCP.

They would like to increase the worker node root disk size beyond the default 300 GiB. The ROSA HCP documentation mentions support for machine pool disk sizing (for example via --worker-disk-size), but we have not been able to find a way to configure this when using the official Terraform module.

The underlying provider supports it since version 1.6.5 https://github.com/terraform-redhat/terraform-provider-rhcs/blob/main/CHANGELOG.md 

But the module does not have a variable that allows this option to be passed.

2) why this change is needed,
To be able to choose disk size for default worker nodepool at creation time. Rosa cli supports already this with the (--worker-disk-size) flag.

3) what changed,
Only added variables needed for this feature to be enables and be passed to the underlying provider (https://github.com/terraform-redhat/terraform-provider-rhcs)

4) how you validated it.
I have made the terraform init and terraform validate. I crated a terraform main.tf using the documentation found in https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_clusters/creating-a-red-hat-openshift-service-on-aws-cluster-with-terraform  and adding the new parameter as a variable like so :

`module "rosa-hcp" {
  source                 = "terraform-redhat/rosa-hcp/rhcs"
  version                = "1.6.3"
  cluster_name           = local.cluster_name
  openshift_version      = var.openshift_version
  account_role_prefix    = local.cluster_name
  operator_role_prefix   = local.cluster_name
  replicas               = local.worker_node_replicas
  aws_availability_zones = local.region_azs
  ...
  worker_disk_size.  = 400`

I deployed a full cluster and verified the nodepools were the correct disk size passed during creation .



Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For details, see: ./CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable worker node root disk size (GiB) for the default worker machine pool; leaving it unset uses the platform default.
  * Input validated to require a positive whole number when specified, with a clear error message.

* **Tests**
  * Added plan-mode tests confirming passthrough behavior for both unset and numeric disk-size values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->