### PR TITLE
ROSAENG-57757 | fix: apply trust_policy_external_id to support role trust policy

### DIFF
--- a/modules/account-iam-resources/README.md
+++ b/modules/account-iam-resources/README.md
@@ -56,7 +56,6 @@ No modules.
 | [random_string.default_random](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [time_sleep.account_iam_resources_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_iam_policy_document.custom_trust_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [rhcs_hcp_policies.all_policies](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/data-sources/hcp_policies) | data source |
 | [rhcs_info.current](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/data-sources/info) | data source |

--- a/modules/account-iam-resources/main.tf
+++ b/modules/account-iam-resources/main.tf
@@ -3,6 +3,9 @@
 
 locals {
   path = coalesce(var.path, "/")
+  trust_policy_external_id = (
+    var.trust_policy_external_id != null && var.trust_policy_external_id != ""
+  ) ? var.trust_policy_external_id : null
   account_roles_properties = [
     {
       role_name            = "HCP-ROSA-Installer"
@@ -10,7 +13,7 @@ locals {
       policy_details       = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/ROSAInstallerPolicy"
       principal_type       = "AWS"
       principal_identifier = "arn:${data.aws_partition.current.partition}:iam::${data.rhcs_info.current.ocm_aws_account_id}:role/RH-Managed-OpenShift-Installer"
-      external_id          = var.trust_policy_external_id
+      external_id          = local.trust_policy_external_id
     },
     {
       role_name      = "HCP-ROSA-Support"
@@ -19,7 +22,7 @@ locals {
       principal_type = "AWS"
       // This is a SRE RH Support role which is used to assume this support role
       principal_identifier = data.rhcs_hcp_policies.all_policies.account_role_policies["sts_support_rh_sre_role"]
-      external_id          = null
+      external_id          = local.trust_policy_external_id
     },
     {
       role_name            = "HCP-ROSA-Worker"
@@ -45,6 +48,32 @@ locals {
   vpce_role_name          = local.vpce_splits[length(local.vpce_splits) - 1]
   vpce_policy_name        = substr("${local.vpce_role_name}-assume-role", 0, 64)
   policy_arn_base         = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy"
+  # jsonencode instead of aws_iam_policy_document: trades structural validation for plan-time testability via terraform test.
+  custom_trust_policy_json = [
+    for idx in range(local.account_roles_count) : jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        merge(
+          {
+            Effect = "Allow"
+            Action = "sts:AssumeRole"
+            Principal = local.account_roles_properties[idx].principal_type == "AWS" ? {
+              AWS = local.account_roles_properties[idx].principal_identifier
+              } : {
+              Service = local.account_roles_properties[idx].principal_identifier
+            }
+          },
+          local.account_roles_properties[idx].external_id != null ? {
+            Condition = {
+              StringEquals = {
+                "sts:ExternalId" = local.account_roles_properties[idx].external_id
+              }
+            }
+          } : {}
+        )
+      ]
+    })
+  ]
 }
 
 data "aws_caller_identity" "current" {}
@@ -55,35 +84,12 @@ data "aws_partition" "current" {}
 
 data "rhcs_info" "current" {}
 
-data "aws_iam_policy_document" "custom_trust_policy" {
-  count = local.account_roles_count
-
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-    principals {
-      type        = local.account_roles_properties[count.index].principal_type
-      identifiers = [local.account_roles_properties[count.index].principal_identifier]
-    }
-
-    dynamic "condition" {
-      # Only set this condition if "trust_policy_external_id" is set
-      for_each = (local.account_roles_properties[count.index].external_id != null) ? [1] : []
-      content {
-        test     = "StringEquals"
-        variable = "sts:ExternalId"
-        values   = [local.account_roles_properties[count.index].external_id]
-      }
-    }
-  }
-}
-
 resource "aws_iam_role" "account_role" {
   count                = local.account_roles_count
   name                 = substr("${local.account_role_prefix_valid}-${local.account_roles_properties[count.index].role_name}-Role", 0, 64)
   permissions_boundary = var.permissions_boundary
   path                 = local.path
-  assume_role_policy   = data.aws_iam_policy_document.custom_trust_policy[count.index].json
+  assume_role_policy   = local.custom_trust_policy_json[count.index]
 
   tags = merge(var.tags, {
     red-hat-managed       = true
@@ -165,6 +171,6 @@ resource "time_sleep" "account_iam_resources_wait" {
     account_role_prefix           = local.account_role_prefix_valid
     path                          = local.path
     shared_vpc_policy_attachments = local.route53_shared_role_arn != "" && local.vpce_shared_role_arn != "" ? jsonencode([aws_iam_role_policy_attachment.route53_policy_installer_account_role_attachment[0].policy_arn, aws_iam_role_policy_attachment.vpce_policy_installer_account_role_attachment[0].policy_arn]) : jsonencode([])
-    trust_policy_external_id      = var.trust_policy_external_id
+    trust_policy_external_id      = local.trust_policy_external_id
   }
 }

--- a/modules/account-iam-resources/outputs.tf
+++ b/modules/account-iam-resources/outputs.tf
@@ -25,3 +25,4 @@ output "trust_policy_external_id" {
   value       = time_sleep.account_iam_resources_wait.triggers["trust_policy_external_id"]
   description = "External ID for trust policy condition in account roles"
 }
+

--- a/modules/account-iam-resources/tests/trust_policy_external_id.tftest.hcl
+++ b/modules/account-iam-resources/tests/trust_policy_external_id.tftest.hcl
@@ -1,0 +1,208 @@
+// Copyright Red Hat
+// SPDX-License-Identifier: Apache-2.0
+
+mock_provider "aws" {
+  alias = "default"
+
+  mock_data "aws_partition" {
+    defaults = {
+      partition = "aws"
+    }
+  }
+
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+    }
+  }
+
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn  = "arn:aws:iam::123456789012:role/mock"
+      id   = "mock-role-id"
+      name = "mock-role"
+    }
+  }
+
+  mock_resource "aws_iam_role_policy_attachment" {
+    defaults = {
+      id = "mock-attachment-id"
+    }
+  }
+}
+
+mock_provider "rhcs" {
+  alias = "default"
+
+  mock_data "rhcs_hcp_policies" {
+    defaults = {
+      account_role_policies = {
+        sts_support_rh_sre_role = "arn:aws:iam::999999999999:role/RH-SRE-Support"
+      }
+    }
+  }
+
+  mock_data "rhcs_info" {
+    defaults = {
+      ocm_aws_account_id = "999999999999"
+    }
+  }
+}
+
+mock_provider "time" {
+  alias = "default"
+
+  mock_resource "time_sleep" {
+    defaults = {
+      id = "mock-sleep"
+    }
+  }
+}
+
+mock_provider "random" {
+  alias = "default"
+}
+
+variables {
+  account_role_prefix = "tf-test-acc"
+}
+
+run "null_external_id_omits_condition" {
+  command = plan
+
+  providers = {
+    aws    = aws.default
+    rhcs   = rhcs.default
+    time   = time.default
+    random = random.default
+  }
+
+  variables {
+    trust_policy_external_id = null
+  }
+
+  assert {
+    condition     = !strcontains(aws_iam_role.account_role[0].assume_role_policy, "sts:ExternalId")
+    error_message = "Installer trust policy must not include sts:ExternalId when trust_policy_external_id is null."
+  }
+
+  assert {
+    condition     = !strcontains(aws_iam_role.account_role[1].assume_role_policy, "sts:ExternalId")
+    error_message = "Support trust policy must not include sts:ExternalId when trust_policy_external_id is null."
+  }
+}
+
+run "empty_external_id_rejected" {
+  command = plan
+
+  providers = {
+    aws    = aws.default
+    rhcs   = rhcs.default
+    time   = time.default
+    random = random.default
+  }
+
+  variables {
+    trust_policy_external_id = ""
+  }
+
+  expect_failures = [
+    var.trust_policy_external_id,
+  ]
+}
+
+run "whitespace_external_id_rejected" {
+  command = plan
+
+  providers = {
+    aws    = aws.default
+    rhcs   = rhcs.default
+    time   = time.default
+    random = random.default
+  }
+
+  variables {
+    trust_policy_external_id = "   "
+  }
+
+  expect_failures = [
+    var.trust_policy_external_id,
+  ]
+}
+
+run "non_empty_external_id_adds_condition_to_installer_and_support" {
+  command = plan
+
+  providers = {
+    aws    = aws.default
+    rhcs   = rhcs.default
+    time   = time.default
+    random = random.default
+  }
+
+  variables {
+    trust_policy_external_id = "test-external-id-12345"
+  }
+
+  assert {
+    condition = strcontains(
+      aws_iam_role.account_role[0].assume_role_policy,
+      "test-external-id-12345",
+    )
+    error_message = "Installer trust policy must include the configured external ID."
+  }
+
+  assert {
+    condition = strcontains(
+      aws_iam_role.account_role[1].assume_role_policy,
+      "test-external-id-12345",
+    )
+    error_message = "Support trust policy must include the configured external ID."
+  }
+
+  assert {
+    condition = strcontains(
+      aws_iam_role.account_role[0].assume_role_policy,
+      "sts:ExternalId",
+    )
+    error_message = "Installer trust policy must include sts:ExternalId condition key."
+  }
+
+  assert {
+    condition = strcontains(
+      aws_iam_role.account_role[1].assume_role_policy,
+      "sts:ExternalId",
+    )
+    error_message = "Support trust policy must include sts:ExternalId condition key."
+  }
+}
+
+run "worker_never_includes_external_id" {
+  command = plan
+
+  providers = {
+    aws    = aws.default
+    rhcs   = rhcs.default
+    time   = time.default
+    random = random.default
+  }
+
+  variables {
+    trust_policy_external_id = "test-external-id-12345"
+  }
+
+  assert {
+    condition     = !strcontains(aws_iam_role.account_role[2].assume_role_policy, "sts:ExternalId")
+    error_message = "Worker trust policy must never include sts:ExternalId."
+  }
+
+  assert {
+    condition     = strcontains(aws_iam_role.account_role[2].assume_role_policy, "ec2.amazonaws.com")
+    error_message = "Worker role trust policy must trust ec2.amazonaws.com."
+  }
+
+  assert {
+    condition     = length(aws_iam_role.account_role) == 3
+    error_message = "account_iam_resources must create Installer, Support, and Worker roles."
+  }
+}

--- a/modules/account-iam-resources/variables.tf
+++ b/modules/account-iam-resources/variables.tf
@@ -44,4 +44,9 @@ variable "trust_policy_external_id" {
   type        = string
   default     = null
   description = "External ID for trust policy condition in account roles"
+
+  validation {
+    condition     = var.trust_policy_external_id == null ? true : length(trimspace(var.trust_policy_external_id)) > 0
+    error_message = "trust_policy_external_id must be null or a non-empty, non-whitespace string"
+  }
 }


### PR DESCRIPTION
## PR Summary

Fixes `modules/account-iam-resources` so `trust_policy_external_id` is injected into the **support** role trust policy (not just installer) and empty strings are treated as unset.

## Detailed Description of the Issue

The HCP `account-iam-resources` module already exposed `trust_policy_external_id`, but only the installer role received the `sts:ExternalId` trust policy condition. The support role had `external_id = null`, so cluster create validation in the RHCS provider (which requires the external ID in **both** installer and support policies) would fail even when users configured the module correctly.

This change aligns HCP module behavior with ROSA product expectations and with the new Classic module implementation.

## Related Issues and PRs

- Jira: [ROSAENG-57757](https://issues.redhat.com/browse/ROSAENG-57757)
- Related PR(s):
  - [terraform-provider-rhcs](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1190): `sts.trust_policy_external_id` on cluster resources and create-time validation
  - [terraform-rhcs-rosa-classic](https://github.com/terraform-redhat/terraform-rhcs-rosa-classic/pull/149): new `trust_policy_external_id` support in account-iam-resources

## Type of Change

- [ ] feat - adds a new module capability or new user-facing behavior.
- [x] fix - resolves incorrect module behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting/naming changes with no logic impact.
- [ ] refactor - module code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

- `trust_policy_external_id` applied to installer role trust policy only.
- Support role trust policy never received `sts:ExternalId` when the variable was set.
- Empty string passed through as-is (could produce invalid or unintended conditions).

## Behavior After This Change

- `local.trust_policy_external_id` normalizes `null` and `""` to unset.
- Installer **and** support roles use `local.trust_policy_external_id` for trust policy conditions.
- Worker role unchanged (no external ID).
- `time_sleep` triggers use normalized local value.

### Example wiring

```hcl
module "account_iam_resources" {
  source  = "terraform-redhat/rosa-hcp/rhcs//modules/account-iam-resources"
  version = ">=1.6.3"

  account_role_prefix      = var.account_role_prefix
  trust_policy_external_id = var.trust_policy_external_id
}

resource "rhcs_cluster_rosa_hcp" "example" {
  sts = {
    trust_policy_external_id = var.trust_policy_external_id
    # role_arn, support_role_arn, ...
  }
}
```

## How to Test (Step-by-Step)

### Preconditions

- AWS credentials for target account
- RHCS provider configured
- Terraform >= 1.0

### Test Steps

1. Format module:
   ```bash
   cd modules/account-iam-resources
   terraform fmt
   ```
2. Apply module with `trust_policy_external_id = "test-external-id-123"`.
3. In AWS IAM, verify **both** HCP-ROSA-Installer and HCP-ROSA-Support role trust policies include `sts:ExternalId` with the same value.
4. Verify HCP-ROSA-Worker role trust policy has no external ID condition.
5. Re-apply with `trust_policy_external_id = null`; confirm conditions are removed on new role creation (or validate on fresh prefix).

### Expected Results

- Installer and support trust policies match for external ID when variable is set.
- RHCS provider create-time validation passes when cluster uses the same value.
- Worker role unaffected.

## Proof of the Fix

- Screenshots: IAM trust policies for installer and support showing matching `sts:ExternalId`
- Videos: N/A
- Logs/CLI output: `terraform apply` output
- Other artifacts: N/A

## Breaking Changes

- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan

N/A for new deployments. 

**Note for existing deployments:** clusters created with external ID on installer only may need support role trust policy updated (re-apply module or manual IAM update) before RHCS provider validation will pass when `sts.trust_policy_external_id` is set on the cluster.

## Developer Verification Checklist

- [ ] **AWS-only changes:** N/A — module uses RHCS data sources; change aligns account role IAM with provider validation.
- [ ] I checked if this affects terraform-rhcs-rosa-classic and submitted (or already submitted) a companion PR when needed.
- [ ] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [ ] PR description clearly explains both **what** changed and **why**.
- [ ] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] Tests were added/updated where appropriate.
- [ ] I manually tested the change.
- [ ] `make pre-push-checks` passes (or each step: `verify`, `verify-gen`, `lint`, `unit-tests`, `license-check`, `docs-lint`).
- [ ] Documentation was added/updated where appropriate (see `make terraform-docs`).
- [ ] Any risk, limitation, or follow-up work is documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Normalized `trust_policy_external_id` so empty/unset values behave as `null`, omitting the `sts:ExternalId` condition for installer/support roles while keeping worker free of `sts:ExternalId`.

* **New Features**
  * Added an output that exposes the rendered trust-policy JSON used for account roles.

* **Validation & Tests**
  * Added input validation to reject empty/whitespace external IDs.
  * Expanded tests to verify omit/include behavior across roles and expected failure cases.

* **Documentation**
  * Updated module docs to reflect the new trust-policy output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->