### PR TITLE
ROSAENG-59990: test: Cleanup VPC

### DIFF
--- a/examples/rosa-hcp-private-shared-vpc/main.tf
+++ b/examples/rosa-hcp-private-shared-vpc/main.tf
@@ -106,8 +106,9 @@ module "vpc" {
     aws = aws.network-owner
   }
 
-  name_prefix              = local.shared_resources_name_prefix
-  availability_zones_count = 1
+  name_prefix                       = local.shared_resources_name_prefix
+  availability_zones_count          = 1
+  cleanup_rosa_vpce_security_groups = true
 }
 
 ############################

--- a/examples/rosa-hcp-private-with-additional-control-plane-security-groups/main.tf
+++ b/examples/rosa-hcp-private-with-additional-control-plane-security-groups/main.tf
@@ -91,8 +91,9 @@ resource "random_password" "password" {
 module "vpc" {
   source = "../../modules/vpc"
 
-  name_prefix              = var.cluster_name
-  availability_zones_count = 1
+  name_prefix                       = var.cluster_name
+  availability_zones_count          = 1
+  cleanup_rosa_vpce_security_groups = true
 }
 
 ############################

--- a/examples/rosa-hcp-private/main.tf
+++ b/examples/rosa-hcp-private/main.tf
@@ -46,8 +46,9 @@ resource "random_password" "password" {
 module "vpc" {
   source = "../../modules/vpc"
 
-  name_prefix              = var.cluster_name
-  availability_zones_count = 1
+  name_prefix                       = var.cluster_name
+  availability_zones_count          = 1
+  cleanup_rosa_vpce_security_groups = true
 }
 
 ############################

--- a/examples/rosa-hcp-public-unmanaged-oidc/main.tf
+++ b/examples/rosa-hcp-public-unmanaged-oidc/main.tf
@@ -55,6 +55,7 @@ resource "random_password" "password" {
 module "vpc" {
   source = "../../modules/vpc"
 
-  name_prefix              = var.cluster_name
-  availability_zones_count = 3
+  name_prefix                       = var.cluster_name
+  availability_zones_count          = 3
+  cleanup_rosa_vpce_security_groups = true
 }

--- a/examples/rosa-hcp-public-with-multiple-machinepools-and-idps/main.tf
+++ b/examples/rosa-hcp-public-with-multiple-machinepools-and-idps/main.tf
@@ -162,7 +162,8 @@ resource "random_password" "password" {
 module "vpc" {
   source = "../../modules/vpc"
 
-  name_prefix              = var.cluster_name
-  availability_zones_count = 3
+  name_prefix                       = var.cluster_name
+  availability_zones_count          = 3
+  cleanup_rosa_vpce_security_groups = true
 }
 

--- a/examples/rosa-hcp-public-with-sts-external-id/main.tf
+++ b/examples/rosa-hcp-public-with-sts-external-id/main.tf
@@ -31,6 +31,7 @@ module "hcp" {
 module "vpc" {
   source = "../../modules/vpc"
 
-  name_prefix              = var.cluster_name
-  availability_zones_count = 3
+  name_prefix                       = var.cluster_name
+  availability_zones_count          = 3
+  cleanup_rosa_vpce_security_groups = true
 }

--- a/examples/rosa-hcp-public/main.tf
+++ b/examples/rosa-hcp-public/main.tf
@@ -56,6 +56,7 @@ resource "random_password" "password" {
 module "vpc" {
   source = "../../modules/vpc"
 
-  name_prefix              = var.cluster_name
-  availability_zones_count = 3
+  name_prefix                       = var.cluster_name
+  availability_zones_count          = 3
+  cleanup_rosa_vpce_security_groups = true
 }

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -22,6 +22,7 @@ module "vpc" {
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.38.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.4 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9 |
 
 ## Providers
@@ -29,6 +30,7 @@ module "vpc" {
 | Name | Version |
 | ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.38.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.4 |
 | <a name="provider_time"></a> [time](#provider\_time) | >= 0.9 |
 
 ## Modules
@@ -54,6 +56,7 @@ No modules.
 | [aws_vpc.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 | [aws_vpc_endpoint.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_vpc_endpoint_route_table_association.private_vpc_endpoint_route_table_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_route_table_association) | resource |
+| [null_resource.vpc_destroy_cleanup](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [time_sleep.vpc_resources_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
@@ -64,6 +67,7 @@ No modules.
 | ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | A list of availability zones names in the region. This value should not be updated, please create a new resource instead | `list(string)` | `null` | no |
 | <a name="input_availability_zones_count"></a> [availability\_zones\_count](#input\_availability\_zones\_count) | The count of availability zones to use within the specified AWS Region, where pairs of public and private subnets will be generated. Valid only when availability\_zones variable is not provided. This value should not be updated, please create a new resource instead | `number` | `null` | no |
+| <a name="input_cleanup_rosa_vpce_security_groups"></a> [cleanup\_rosa\_vpce\_security\_groups](#input\_cleanup\_rosa\_vpce\_security\_groups) | On destroy, remove orphaned ROSA HCP PrivateLink security groups (name suffix -vpce-private-router) left in this VPC after cluster deletion. Enable for ROSA HCP clusters using this module; requires AWS CLI and EC2 permissions at destroy time. | `bool` | `false` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | User-defined prefix for all generated AWS resources of this VPC. This value should not be updated, please create a new resource instead | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | AWS tags to be applied to generated AWS resources of this VPC. | `map(string)` | `null` | no |
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | Cidr block of the desired VPC. This value should not be updated, please create a new resource instead | `string` | `"10.0.0.0/16"` | no |

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -204,9 +204,26 @@ resource "aws_route_table_association" "private_route_table_association" {
 
 # This resource is used in order to add dependencies on all resources 
 # Any resource uses this VPC ID, must wait to all resources creation completion
+# Optional destroy hook: after time_sleep.vpc_resources_wait completes its destroy wait,
+# remove orphaned ROSA HCP VPCE security groups that block VPC deletion (DependencyViolation).
+resource "null_resource" "vpc_destroy_cleanup" {
+  count = var.cleanup_rosa_vpce_security_groups ? 1 : 0
+
+  triggers = {
+    vpc_id = aws_vpc.vpc.id
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "bash ${path.module}/../../scripts/vpc-destroy-cleanup.sh '${self.triggers.vpc_id}'"
+  }
+}
+
 resource "time_sleep" "vpc_resources_wait" {
+  depends_on = [null_resource.vpc_destroy_cleanup]
+
   create_duration  = "20s"
-  destroy_duration = "20s"
+  destroy_duration = "5m"
   triggers = {
     vpc_id                                           = aws_vpc.vpc.id
     cidr_block                                       = aws_vpc.vpc.cidr_block

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -29,3 +29,9 @@ variable "tags" {
   default     = null
   description = "AWS tags to be applied to generated AWS resources of this VPC."
 }
+
+variable "cleanup_rosa_vpce_security_groups" {
+  type        = bool
+  default     = false
+  description = "On destroy, remove orphaned ROSA HCP PrivateLink security groups (name suffix -vpce-private-router) left in this VPC after cluster deletion. Enable for ROSA HCP clusters using this module; requires AWS CLI and EC2 permissions at destroy time."
+}

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -13,5 +13,9 @@ terraform {
       source  = "hashicorp/time"
       version = ">= 0.9"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.2.4"
+    }
   }
 }

--- a/scripts/vpc-destroy-cleanup.sh
+++ b/scripts/vpc-destroy-cleanup.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+VPC_ID="${1:-}"
+
+if [[ -z "$VPC_ID" ]]; then
+  echo "usage: $0 <vpc-id>" >&2
+  exit 1
+fi
+
+MAX_ATTEMPTS="${VPC_DESTROY_CLEANUP_MAX_ATTEMPTS:-12}"
+INITIAL_BACKOFF_SECONDS="${VPC_DESTROY_CLEANUP_INITIAL_BACKOFF_SECONDS:-10}"
+MAX_BACKOFF_SECONDS="${VPC_DESTROY_CLEANUP_MAX_BACKOFF_SECONDS:-60}"
+
+VPCE_ROUTER_SG_QUERY="SecurityGroups[?GroupName!=\`default\` && contains(GroupName, \`-vpce-private-router\`)].[GroupId,GroupName,Description]"
+NON_VPCE_SG_QUERY="SecurityGroups[?GroupName!=\`default\` && !contains(GroupName, \`-vpce-private-router\`)].[GroupId,GroupName,Description]"
+
+count_vpce_private_router_sgs() {
+  aws ec2 describe-security-groups \
+    --filters "Name=vpc-id,Values=${VPC_ID}" \
+    --query "length(${VPCE_ROUTER_SG_QUERY})" \
+    --output text
+}
+
+delete_detached_vpce_router_sgs() {
+  while IFS=$'\t' read -r sg_id sg_name _sg_desc; do
+    [[ -z "$sg_id" || "$sg_id" == "None" ]] && continue
+
+    attached_enis="$(aws ec2 describe-network-interfaces \
+      --filters "Name=group-id,Values=${sg_id}" \
+      --query 'length(NetworkInterfaces)' \
+      --output text)"
+
+    if [[ "$attached_enis" != "0" ]]; then
+      continue
+    fi
+
+    if ! aws ec2 delete-security-group --group-id "$sg_id"; then
+      echo "Warning: failed to delete security group ${sg_id} (${sg_name})" >&2
+    fi
+  done < <(aws ec2 describe-security-groups \
+    --filters "Name=vpc-id,Values=${VPC_ID}" \
+    --query "${VPCE_ROUTER_SG_QUERY}" \
+    --output text)
+}
+
+attempt=1
+backoff="$INITIAL_BACKOFF_SECONDS"
+
+while [[ "$attempt" -le "$MAX_ATTEMPTS" ]]; do
+  delete_detached_vpce_router_sgs
+
+  remaining_vpce="$(count_vpce_private_router_sgs)"
+  if [[ "$remaining_vpce" == "0" ]]; then
+    other_count="$(aws ec2 describe-security-groups \
+      --filters "Name=vpc-id,Values=${VPC_ID}" \
+      --query "length(${NON_VPCE_SG_QUERY})" \
+      --output text)"
+
+    if [[ "$other_count" != "0" ]]; then
+      echo "Warning: VPC ${VPC_ID} has ${other_count} non-default security group(s) outside *-vpce-private-router cleanup scope." >&2
+      aws ec2 describe-security-groups \
+        --filters "Name=vpc-id,Values=${VPC_ID}" \
+        --query "${NON_VPCE_SG_QUERY}" \
+        --output table >&2
+    fi
+    exit 0
+  fi
+
+  if [[ "$attempt" -eq "$MAX_ATTEMPTS" ]]; then
+    break
+  fi
+
+  echo "VPC ${VPC_ID} still has ${remaining_vpce} *-vpce-private-router security group(s); retrying in ${backoff}s (attempt ${attempt}/${MAX_ATTEMPTS})..." >&2
+  sleep "$backoff"
+  backoff=$((backoff * 2))
+  if [[ "$backoff" -gt "$MAX_BACKOFF_SECONDS" ]]; then
+    backoff="$MAX_BACKOFF_SECONDS"
+  fi
+  attempt=$((attempt + 1))
+done
+
+echo "VPC ${VPC_ID} still has ${remaining_vpce} *-vpce-private-router security group(s) after cleanup." >&2
+aws ec2 describe-security-groups \
+  --filters "Name=vpc-id,Values=${VPC_ID}" \
+  --query "${VPCE_ROUTER_SG_QUERY}" \
+  --output table >&2
+exit 1


### PR DESCRIPTION
<!--
Please provide enough context so reviewers can understand:
1) the problem,
2) why this change is needed,
3) what changed,
4) how you validated it.

Use N/A when an item does not apply.

Commit format requirement:
[JIRA-TICKET] | [TYPE]: <MESSAGE>
TYPE must be one of:
feat, fix, docs, style, refactor, test, chore, build, ci, perf
For details, see: ./CONTRIBUTING.md
-->

## PR Summary
Fix ROSA HCP example `terraform destroy` VPC failures by optionally removing orphaned PrivateLink `*-vpce-private-router` security groups after cluster deletion, with retry/backoff while ENIs detach.

**NOTE** : If this test works https://github.com/terraform-redhat/terraform-rhcs-rosa-hcp/pull/170 , the cleanup script probably wont be needed any more.

## Detailed Description of the Issue
ROSA HCP creates a VPC endpoint security group named `{cluster-id}-vpce-private-router` that is not managed by Terraform. After `rhcs_cluster_rosa_hcp` is destroyed, this security group can remain in the customer VPC while ENIs are still detaching. `aws_vpc` / subnet delete then fails with `DependencyViolation` in Prow example jobs (`rosa-hcp-private`, `rosa-hcp-public`). Increasing `time_sleep` destroy duration alone does not remove the orphaned security group.

## Related Issues and PRs
- Jira: [ROSAENG-59990](https://issues.redhat.com/browse/ROSAENG-59990)
- Fixes: N/A
- Related PR(s): N/A
- Related design/docs: N/A

## Type of Change
- [ ] feat - adds a new module capability or new user-facing behavior.
- [ ] fix - resolves incorrect module behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting/naming changes with no logic impact.
- [ ] refactor - module code restructuring with no behavior change.
- [x] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior
`modules/vpc` waited 20s on destroy (`time_sleep.vpc_resources_wait`) and then deleted VPC resources. Orphaned ROSA HCP `*-vpce-private-router` security groups blocked `aws_vpc` deletion with `DependencyViolation`.

## Behavior After This Change
- New opt-in variable `cleanup_rosa_vpce_security_groups` (default `false`) on `modules/vpc`.
- When enabled, destroy runs `scripts/vpc-destroy-cleanup.sh` via `null_resource.vpc_destroy_cleanup` after the 5-minute `time_sleep` destroy wait and before `aws_vpc` delete.
- The script retries deletion of `*-vpce-private-router` security groups with exponential backoff (default 12 attempts) while ENIs detach; logs and continues on individual `delete-security-group` failures.
- Exit `1` only if `*-vpce-private-router` security groups remain after retries; other non-default security groups produce a warning only.
- All HCP examples enable `cleanup_rosa_vpce_security_groups = true`.
- Default module consumers are unchanged unless they opt in.

## How to Test (Step-by-Step)

### Preconditions
- Terraform >= 1.5.7, AWS credentials, `RHCS_TOKEN`, `TF_VAR_cluster_name`
- AWS CLI available (required when cleanup is enabled; present in Prow client image)

### Test Steps
1. Run an HCP example end-to-end: `make run-example EXAMPLE_NAME=rosa-hcp-private` (or `rosa-hcp-public`).
2. Confirm `terraform destroy` completes without `DependencyViolation` on `aws_vpc` or subnets.
3. Optionally tune retries via `VPC_DESTROY_CLEANUP_MAX_ATTEMPTS` if ENI detach is slow.

### Expected Results
- Cluster and VPC resources are destroyed successfully.
- No orphaned `*-vpce-private-router` security groups remain in the example VPC.
- If other non-default security groups remain, the cleanup script prints a warning table to stderr.

## Proof of the Fix
- Screenshots: N/A
- Videos: N/A
- Logs/CLI output: Prow failures showed `DependencyViolation` on VPC/subnet delete and orphaned `*-vpce-private-router` security groups. Manual AWS inspection and `scripts/vpc-destroy-cleanup.sh` confirmed removal unblocks VPC delete. `rosa-hcp-private` passed end-to-end on commit `9a32769`; `rosa-hcp-public` failure traced to VPCE SG still attached during a single-pass cleanup (addressed by retry loop).
- Other artifacts: N/A

## Breaking Changes
- [x] No breaking changes
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan
N/A

## Developer Verification Checklist
- [x] **AWS-only changes:** If this PR is mainly **AWS-only** (no `rhcs` resources/variables), I linked **official Red Hat or cited ROSA HCP documentation** that supports reference alignment, or I explained why the change still belongs in-repo per **`Module scope (AWS-only vs core HCP)`** in [`.cursor/rules/rosa-hcp-terraform.mdc`](.cursor/rules/rosa-hcp-terraform.mdc).
- [ ] I checked if this affects terraform-rhcs-rosa-classic and submitted (or already submitted) a companion PR when needed.
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [ ] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [ ] `make pre-push-checks` passes (or each step: `verify`, `verify-gen`, `lint`, `unit-tests`, `license-check`, `docs-lint`).
- [x] Documentation was added/updated where appropriate (see `make terraform-docs`).
- [x] Any risk, limitation, or follow-up work is documented.
