### PR TITLE
ROSAENG-61734 | feat: Wire delete_protection through ROSA HCP module

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ We recommend you install the following CLI tools:
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.51.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.3.0 |
-| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | >= 1.7.7 |
+| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | >= 1.7.8 |
 
 ## Providers
 
@@ -96,7 +96,7 @@ We recommend you install the following CLI tools:
 | ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.51.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 3.3.0 |
-| <a name="provider_rhcs"></a> [rhcs](#provider\_rhcs) | >= 1.7.7 |
+| <a name="provider_rhcs"></a> [rhcs](#provider\_rhcs) | >= 1.7.8 |
 
 ## Modules
 
@@ -151,6 +151,7 @@ We recommend you install the following CLI tools:
 | <a name="input_create_oidc"></a> [create\_oidc](#input\_create\_oidc) | Create the oidc resources. This value should not be updated, please create a new resource instead or use the submodule to create a new oidc config | `bool` | `false` | no |
 | <a name="input_create_operator_roles"></a> [create\_operator\_roles](#input\_create\_operator\_roles) | Create the aws account roles for rosa | `bool` | `false` | no |
 | <a name="input_default_ingress_listening_method"></a> [default\_ingress\_listening\_method](#input\_default\_ingress\_listening\_method) | Listening Method for ingress. Options are ["internal", "external"]. Default is "external". When empty is set based on private variable. | `string` | `""` | no |
+| <a name="input_delete_protection"></a> [delete\_protection](#input\_delete\_protection) | When true, prevents cluster deletion via Red Hat OpenShift Cluster Manager (OCM). Set to false and apply before running terraform destroy. | `bool` | `null` | no |
 | <a name="input_destroy_timeout"></a> [destroy\_timeout](#input\_destroy\_timeout) | Maximum duration in minutes to allow for destroying resources. (Default: 60 minutes) | `number` | `null` | no |
 | <a name="input_disable_waiting_in_destroy"></a> [disable\_waiting\_in\_destroy](#input\_disable\_waiting\_in\_destroy) | Disable addressing cluster state in the destroy resource. Default value is false, and so a `destroy` will wait for the cluster to be deleted. | `bool` | `null` | no |
 | <a name="input_domain_prefix"></a> [domain\_prefix](#input\_domain\_prefix) | Creates a domain\_prefix for your ROSA cluster. Defaults to a random string if not set | `string` | `null` | no |

--- a/examples/ocm-role/README.md
+++ b/examples/ocm-role/README.md
@@ -9,7 +9,7 @@ Creates and links an OCM IAM role with the required ROSA CLI-parity tags using t
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 6.54.0 |
-| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | = 1.7.7 |
+| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | = 1.7.8 |
 
 ## Providers
 

--- a/examples/ocm-role/versions.tf
+++ b/examples/ocm-role/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     rhcs = {
       source  = "terraform-redhat/rhcs"
-      version = "= 1.7.7"
+      version = "= 1.7.8"
     }
   }
 }

--- a/examples/rosa-hcp-private-shared-vpc/README.md
+++ b/examples/rosa-hcp-private-shared-vpc/README.md
@@ -7,7 +7,7 @@
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 6.54.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
-| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | = 1.7.7 |
+| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | = 1.7.8 |
 
 ## Providers
 
@@ -18,7 +18,7 @@
 | <a name="provider_aws.network-owner"></a> [aws.network-owner](#provider\_aws.network-owner) | = 6.54.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 3.0.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
-| <a name="provider_rhcs"></a> [rhcs](#provider\_rhcs) | = 1.7.7 |
+| <a name="provider_rhcs"></a> [rhcs](#provider\_rhcs) | = 1.7.8 |
 
 ## Modules
 
@@ -39,7 +39,7 @@
 | [aws_ec2_tag.tag_private_subnets](https://registry.terraform.io/providers/hashicorp/aws/6.54.0/docs/resources/ec2_tag) | resource |
 | [null_resource.validations](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_password.password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
-| [rhcs_dns_domain.dns_domain](https://registry.terraform.io/providers/terraform-redhat/rhcs/1.7.7/docs/resources/dns_domain) | resource |
+| [rhcs_dns_domain.dns_domain](https://registry.terraform.io/providers/terraform-redhat/rhcs/1.7.8/docs/resources/dns_domain) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/6.54.0/docs/data-sources/caller_identity) | data source |
 | [aws_caller_identity.shared_vpc](https://registry.terraform.io/providers/hashicorp/aws/6.54.0/docs/data-sources/caller_identity) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/6.54.0/docs/data-sources/partition) | data source |

--- a/examples/rosa-hcp-private-shared-vpc/versions.tf
+++ b/examples/rosa-hcp-private-shared-vpc/versions.tf
@@ -10,7 +10,7 @@ terraform {
       version = "= 6.54.0"
     }
     rhcs = {
-      version = "= 1.7.7"
+      version = "= 1.7.8"
       source  = "terraform-redhat/rhcs"
     }
     random = {

--- a/examples/rosa-hcp-private-with-additional-control-plane-security-groups/README.md
+++ b/examples/rosa-hcp-private-with-additional-control-plane-security-groups/README.md
@@ -115,7 +115,7 @@ module "bastion_host" {
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 6.54.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
-| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | = 1.7.7 |
+| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | = 1.7.8 |
 
 ## Providers
 

--- a/examples/rosa-hcp-private-with-additional-control-plane-security-groups/versions.tf
+++ b/examples/rosa-hcp-private-with-additional-control-plane-security-groups/versions.tf
@@ -10,7 +10,7 @@ terraform {
       version = "= 6.54.0"
     }
     rhcs = {
-      version = "= 1.7.7"
+      version = "= 1.7.8"
       source  = "terraform-redhat/rhcs"
     }
     random = {

--- a/examples/rosa-hcp-private/README.md
+++ b/examples/rosa-hcp-private/README.md
@@ -113,7 +113,7 @@ module "bastion_host" {
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 6.54.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
-| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | = 1.7.7 |
+| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | = 1.7.8 |
 
 ## Providers
 

--- a/examples/rosa-hcp-private/versions.tf
+++ b/examples/rosa-hcp-private/versions.tf
@@ -10,7 +10,7 @@ terraform {
       version = "= 6.54.0"
     }
     rhcs = {
-      version = "= 1.7.7"
+      version = "= 1.7.8"
       source  = "terraform-redhat/rhcs"
     }
     random = {

--- a/examples/rosa-hcp-public-unmanaged-oidc/README.md
+++ b/examples/rosa-hcp-public-unmanaged-oidc/README.md
@@ -73,7 +73,7 @@ module "vpc" {
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 6.54.0 |
-| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | = 1.7.7 |
+| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | = 1.7.8 |
 
 ## Providers
 

--- a/examples/rosa-hcp-public-unmanaged-oidc/versions.tf
+++ b/examples/rosa-hcp-public-unmanaged-oidc/versions.tf
@@ -10,7 +10,7 @@ terraform {
       version = "= 6.54.0"
     }
     rhcs = {
-      version = "= 1.7.7"
+      version = "= 1.7.8"
       source  = "terraform-redhat/rhcs"
     }
   }

--- a/examples/rosa-hcp-public-with-multiple-machinepools-and-idps/README.md
+++ b/examples/rosa-hcp-public-with-multiple-machinepools-and-idps/README.md
@@ -201,7 +201,7 @@ module "vpc" {
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 6.54.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
-| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | = 1.7.7 |
+| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | = 1.7.8 |
 
 ## Providers
 

--- a/examples/rosa-hcp-public-with-multiple-machinepools-and-idps/versions.tf
+++ b/examples/rosa-hcp-public-with-multiple-machinepools-and-idps/versions.tf
@@ -10,7 +10,7 @@ terraform {
       version = "= 6.54.0"
     }
     rhcs = {
-      version = "= 1.7.7"
+      version = "= 1.7.8"
       source  = "terraform-redhat/rhcs"
     }
     random = {

--- a/examples/rosa-hcp-public-with-sts-external-id/README.md
+++ b/examples/rosa-hcp-public-with-sts-external-id/README.md
@@ -67,7 +67,7 @@ module "vpc" {
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 6.54.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
-| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | = 1.7.7 |
+| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | = 1.7.8 |
 
 ## Providers
 

--- a/examples/rosa-hcp-public-with-sts-external-id/versions.tf
+++ b/examples/rosa-hcp-public-with-sts-external-id/versions.tf
@@ -10,7 +10,7 @@ terraform {
       version = "= 6.54.0"
     }
     rhcs = {
-      version = "= 1.7.7"
+      version = "= 1.7.8"
       source  = "terraform-redhat/rhcs"
     }
     random = {

--- a/examples/rosa-hcp-public/README.md
+++ b/examples/rosa-hcp-public/README.md
@@ -72,7 +72,7 @@ module "vpc" {
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 6.54.0 |
-| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | = 1.7.7 |
+| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | = 1.7.8 |
 
 ## Providers
 

--- a/examples/rosa-hcp-public/versions.tf
+++ b/examples/rosa-hcp-public/versions.tf
@@ -10,7 +10,7 @@ terraform {
       version = "= 6.54.0"
     }
     rhcs = {
-      version = "= 1.7.7"
+      version = "= 1.7.8"
       source  = "terraform-redhat/rhcs"
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -113,6 +113,7 @@ module "rosa_cluster_hcp" {
   destroy_timeout                     = var.destroy_timeout
   upgrade_acknowledgements_for        = var.upgrade_acknowledgements_for
   external_auth_providers_enabled     = var.external_auth_providers_enabled
+  delete_protection                   = var.delete_protection
 
   #######################
   # Default Machine Pool

--- a/modules/machine-pool/README.md
+++ b/modules/machine-pool/README.md
@@ -37,13 +37,13 @@ module "mp" {
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | >= 1.7.7 |
+| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | >= 1.7.8 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_rhcs"></a> [rhcs](#provider\_rhcs) | >= 1.7.7 |
+| <a name="provider_rhcs"></a> [rhcs](#provider\_rhcs) | >= 1.7.8 |
 
 ## Modules
 

--- a/modules/machine-pool/versions.tf
+++ b/modules/machine-pool/versions.tf
@@ -6,7 +6,7 @@ terraform {
 
   required_providers {
     rhcs = {
-      version = ">= 1.7.7"
+      version = ">= 1.7.8"
       source  = "terraform-redhat/rhcs"
     }
   }

--- a/modules/ocm-role/README.md
+++ b/modules/ocm-role/README.md
@@ -13,7 +13,7 @@ For more information, see [Understanding OCM role and User role for ROSA](https:
 ```
 module "ocm_role" {
   source  = "terraform-redhat/rosa-hcp/rhcs//modules/ocm-role"
-  version = "1.7.7"
+  version = "1.7.8"
 
   ocm_role_prefix = "ManagedOpenShift"
   profile         = "standard"
@@ -27,14 +27,14 @@ module "ocm_role" {
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
-| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | >= 1.7.7 |
+| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | >= 1.7.8 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
-| <a name="provider_rhcs"></a> [rhcs](#provider\_rhcs) | >= 1.7.7 |
+| <a name="provider_rhcs"></a> [rhcs](#provider\_rhcs) | >= 1.7.8 |
 
 ## Modules
 

--- a/modules/ocm-role/versions.tf
+++ b/modules/ocm-role/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     rhcs = {
       source  = "terraform-redhat/rhcs"
-      version = ">= 1.7.7"
+      version = ">= 1.7.8"
     }
   }
 }

--- a/modules/rosa-cluster-hcp/README.md
+++ b/modules/rosa-cluster-hcp/README.md
@@ -39,14 +39,14 @@ module "rosa_cluster_hcp" {
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
-| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | >= 1.7.7 |
+| <a name="requirement_rhcs"></a> [rhcs](#requirement\_rhcs) | >= 1.7.8 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
-| <a name="provider_rhcs"></a> [rhcs](#provider\_rhcs) | >= 1.7.7 |
+| <a name="provider_rhcs"></a> [rhcs](#provider\_rhcs) | >= 1.7.8 |
 
 ## Modules
 
@@ -92,6 +92,7 @@ No modules.
 | <a name="input_compute_machine_type"></a> [compute\_machine\_type](#input\_compute\_machine\_type) | Identifies the Instance type used by the default worker machine pool e.g. `m5.xlarge`. Use the `rhcs_machine_types` data source to find the possible values. | `string` | `null` | no |
 | <a name="input_create_admin_user"></a> [create\_admin\_user](#input\_create\_admin\_user) | To create cluster admin user with default username `cluster-admin` and generated password. It will be ignored if `admin_credentials_username` or `admin_credentials_password` is set. (default: false) | `bool` | `null` | no |
 | <a name="input_default_ingress_listening_method"></a> [default\_ingress\_listening\_method](#input\_default\_ingress\_listening\_method) | Listening Method for ingress. Options are ["internal", "external"]. Default is "external". When empty is set based on private variable. | `string` | `""` | no |
+| <a name="input_delete_protection"></a> [delete\_protection](#input\_delete\_protection) | When true, prevents cluster deletion via Red Hat OpenShift Cluster Manager (OCM). Set to false and apply before running terraform destroy. | `bool` | `null` | no |
 | <a name="input_destroy_timeout"></a> [destroy\_timeout](#input\_destroy\_timeout) | Maximum duration in minutes to allow for destroying resources. (Default: 60 minutes) | `number` | `null` | no |
 | <a name="input_disable_waiting_in_destroy"></a> [disable\_waiting\_in\_destroy](#input\_disable\_waiting\_in\_destroy) | Disable addressing cluster state in the destroy resource. Default value is false, and so a `destroy` will wait for the cluster to be deleted. | `bool` | `null` | no |
 | <a name="input_domain_prefix"></a> [domain\_prefix](#input\_domain\_prefix) | Creates a domain\_prefix for your ROSA cluster. Defaults to a random string if not set | `string` | `null` | no |

--- a/modules/rosa-cluster-hcp/main.tf
+++ b/modules/rosa-cluster-hcp/main.tf
@@ -78,6 +78,7 @@ resource "rhcs_cluster_rosa_hcp" "rosa_hcp_cluster" {
   admin_credentials                         = local.admin_credentials
   ec2_metadata_http_tokens                  = var.ec2_metadata_http_tokens
   external_auth_providers_enabled           = var.external_auth_providers_enabled
+  delete_protection                         = var.delete_protection
 
   machine_cidr = var.machine_cidr
   service_cidr = var.service_cidr

--- a/modules/rosa-cluster-hcp/tests/rosa_cluster_hcp.tftest.hcl
+++ b/modules/rosa-cluster-hcp/tests/rosa_cluster_hcp.tftest.hcl
@@ -263,3 +263,60 @@ run "worker_disk_size_explicit" {
     error_message = "worker_disk_size must be 400 when explicitly set to 400."
   }
 }
+
+# delete_protection passthrough: null value (provider defaults to false).
+run "delete_protection_null" {
+  command = plan
+
+  providers = {
+    aws  = aws.default
+    rhcs = rhcs.import_sim
+  }
+
+  variables {
+    delete_protection = null
+  }
+
+  assert {
+    condition     = rhcs_cluster_rosa_hcp.rosa_hcp_cluster.delete_protection == false
+    error_message = "delete_protection must be false when unset."
+  }
+}
+
+# delete_protection passthrough: explicit true.
+run "delete_protection_enabled" {
+  command = plan
+
+  providers = {
+    aws  = aws.default
+    rhcs = rhcs.import_sim
+  }
+
+  variables {
+    delete_protection = true
+  }
+
+  assert {
+    condition     = rhcs_cluster_rosa_hcp.rosa_hcp_cluster.delete_protection == true
+    error_message = "delete_protection must be true when explicitly enabled."
+  }
+}
+
+# delete_protection passthrough: explicit false.
+run "delete_protection_disabled" {
+  command = plan
+
+  providers = {
+    aws  = aws.default
+    rhcs = rhcs.import_sim
+  }
+
+  variables {
+    delete_protection = false
+  }
+
+  assert {
+    condition     = rhcs_cluster_rosa_hcp.rosa_hcp_cluster.delete_protection == false
+    error_message = "delete_protection must be false when explicitly disabled."
+  }
+}

--- a/modules/rosa-cluster-hcp/variables.tf
+++ b/modules/rosa-cluster-hcp/variables.tf
@@ -290,6 +290,12 @@ variable "external_auth_providers_enabled" {
   description = "Enable external auth providers on the cluster."
 }
 
+variable "delete_protection" {
+  type        = bool
+  default     = null
+  description = "When true, prevents cluster deletion via Red Hat OpenShift Cluster Manager (OCM). Set to false and apply before running terraform destroy."
+}
+
 ##############################################################
 # Default Machine Pool Variables
 # These attributes are specifically applies for the default Machine Pool and becomes irrelevant once the resource is created.

--- a/modules/rosa-cluster-hcp/versions.tf
+++ b/modules/rosa-cluster-hcp/versions.tf
@@ -10,7 +10,7 @@ terraform {
       version = ">= 6.0.0"
     }
     rhcs = {
-      version = ">= 1.7.7"
+      version = ">= 1.7.8"
       source  = "terraform-redhat/rhcs"
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -224,6 +224,12 @@ variable "external_auth_providers_enabled" {
   description = "Enable external auth providers on the cluster."
 }
 
+variable "delete_protection" {
+  type        = bool
+  default     = null
+  description = "When true, prevents cluster deletion via Red Hat OpenShift Cluster Manager (OCM). Set to false and apply before running terraform destroy."
+}
+
 ##############################################################
 # Default Machine Pool Variables
 # These attributes specifically apply to the default Machine Pool and become irrelevant once the resource is created.

--- a/versions.tf
+++ b/versions.tf
@@ -10,7 +10,7 @@ terraform {
       version = ">= 6.51.0"
     }
     rhcs = {
-      version = ">= 1.7.7"
+      version = ">= 1.7.8"
       source  = "terraform-redhat/rhcs"
     }
     null = {


### PR DESCRIPTION
## PR Summary

Wire optional `delete_protection` through the ROSA HCP module and bump the `rhcs` provider floor to `>= 1.7.8`, enabling module consumers to manage OCM delete protection via Terraform.

## Detailed Description of the Issue

`terraform-provider-rhcs` v1.7.8 adds a `delete_protection` attribute on `rhcs_cluster_rosa_hcp`, but this module did not surface it. Module users could not enable delete protection without forking the module or adding a separate `rhcs_cluster_rosa_hcp` resource override.

This PR adds a root and submodule variable passthrough so HCP cluster deployments can opt into delete protection consistently with the provider and ROSA CLI.

## Related Issues and PRs

- Jira: [ROSAENG-61734](https://issues.redhat.com/browse/ROSAENG-61734)
- Fixes: N/A
- Related PR(s):
  - [terraform-provider-rhcs: `delete_protection` on cluster resources](https://github.com/terraform-redhat/terraform-provider-rhcs/pull/1256)
  - [terraform-rhcs-rosa-classic: companion PR for Classic module](https://github.com/terraform-redhat/terraform-rhcs-rosa-classic/pull/174)
  - [ROSA CLI: create-time `--enable-delete-protection`](https://github.com/openshift/rosa/pull/3367)
- Related design/docs: [`developer-docs/variables.md`](developer-docs/variables.md), provider `delete_protection` schema

## Type of Change

- [x] feat - adds a new module capability or new user-facing behavior.
- [ ] fix - resolves incorrect module behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting/naming changes with no logic impact.
- [ ] refactor - module code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

- No `delete_protection` variable on the root module or `modules/rosa-cluster-hcp`.
- Module could not set OCM delete protection via Terraform.
- Destroy behavior followed provider defaults (no module-level guard configuration).

## Behavior After This Change

- **`var.delete_protection`** (optional `bool`, default `null`) added at root and submodule levels.
- Passed through to `rhcs_cluster_rosa_hcp.delete_protection` in `modules/rosa-cluster-hcp/main.tf`.
- When `true`, the provider enables OCM delete protection; `terraform destroy` is blocked until set to `false` and applied.
- When unset/`null`, the provider defaults to `false` (no change to existing deployments).
- Provider floor raised: root `>= 1.7.8`, `modules/rosa-cluster-hcp >= 1.7.8`, `modules/machine-pool >= 1.7.8`, `modules/ocm-role >= 1.7.8`; examples pinned to `= 1.7.8`.
- Variable descriptions use full product name "Red Hat OpenShift Cluster Manager (OCM)".
- Terraform tests added for `delete_protection` passthrough (null, true, false).
- Makefile `verify` target updated for cross-platform `sed` compatibility (macOS + Linux).

## How to Test (Step-by-Step)

### Preconditions

- Terraform CLI >= 1.5.7 (module minimum); >= 1.7 for `mock_provider` tests.
- `terraform-redhat/rhcs` provider >= 1.7.8.
- No live credentials required — tests use mock providers.

### Test Steps

1. Run full module verification:
   ```bash
   make pre-push-checks
   ```
2. Run HCP submodule tests individually:
   ```bash
   cd modules/rosa-cluster-hcp
   terraform init -backend=false
   terraform test
   ```
3. (Optional, manual) Apply with `delete_protection = true`, confirm cluster creates successfully, run `terraform destroy` and confirm the provider blocks until protection is disabled.

### Expected Results

1. `make pre-push-checks` passes (`verify`, `verify-gen`, `lint`, `unit-tests`, `license-check`, `docs-lint`).
2. All three `delete_protection` test runs pass (null → false, true → true, false → false).
3. Manual apply/destroy behaves per provider documentation.

## Proof of the Fix

- Logs/CLI output: `make pre-push-checks` and `terraform test` pass with rhcs provider 1.7.8.

## Breaking Changes

- [x] No breaking changes to module inputs (new optional variable; default `null` preserves existing behavior)
- [ ] Yes, this PR introduces a breaking change (describe impact and migration plan below)

### Breaking Change Details / Migration Plan

**Module interface:** N/A — existing configurations that omit `delete_protection` are unchanged.

**Provider dependency:** The `rhcs` provider floor is raised from `>= 1.7.7` to `>= 1.7.8`. Consumers already on `>= 1.7.7` only need a patch bump.

## Developer Verification Checklist

- [ ] **AWS-only changes:** N/A — this change wires an `rhcs` resource attribute.
- [x] I checked if this affects terraform-rhcs-rosa-classic and submitted (or already submitted) a companion PR when needed.
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make pre-push-checks` passes (or each step: `verify`, `verify-gen`, `lint`, `unit-tests`, `license-check`, `docs-lint`).
- [x] Documentation was added/updated where appropriate (see `make terraform-docs`).
- [x] Any risk, limitation, or follow-up work is documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional cluster deletion protection setting.
  - When enabled, deletion through OCM is blocked.
  - Protection must be disabled before running `terraform destroy`.

- **Documentation**
  - Documented deletion protection behavior and the required pre-destroy workflow.
  - Updated the minimum required RHCS provider version to 1.7.8.

- **Tests**
  - Added coverage for unset, enabled, and disabled deletion protection values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->